### PR TITLE
Fixed typo from "Decline and" to "Decline an"

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1296,7 +1296,7 @@ Approve an incoming Agreement
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ApproveAgreementResponse](#schemaapproveagreementresponse)|
 
-## Decline and Agreement
+## Decline an Agreement
 
 <a id="opIdDeclineAgreement"></a>
 
@@ -1434,7 +1434,7 @@ func main() {
 
 Decline an incoming Agreement
 
-<h3 id="Decline-and-Agreement-parameters" class="parameters">Parameters</h3>
+<h3 id="Decline-an-Agreement-parameters" class="parameters">Parameters</h3>
 
 |Parameter|In|Type|Required|Description|
 |---|---|---|---|---|
@@ -1470,7 +1470,7 @@ Decline an incoming Agreement
 }
 ```
 
-<h3 id="Decline and Agreement-responses">Responses</h3>
+<h3 id="Decline an Agreement-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1869,7 +1869,7 @@ paths:
     post:
       tags:
         - Agreements
-      summary: Decline and Agreement
+      summary: Decline an Agreement
       description: Decline an incoming Agreement
       operationId: DeclineAgreement
       parameters:


### PR DESCRIPTION
 Fixed similar typo "Decline and" to "Decline and"
also Fixed similar typo "Decline-and" to "Decline-an"
from files ./source/index.html.md and ./source/openapi3/split.yaml