### PR TITLE
Add note about including Accepts header

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -38,6 +38,7 @@ Due to the above, certain endpoints and techniques will differ slightly dependin
 * Sandbox API: `https://api.sandbox.split.cash/`.
 * Sandbox UI: `https://go.sandbox.split.cash/`.
 * Data is sent and received as JSON.
+* Clients should include the `Accepts: application/json` header in their requests.
 * Currencies are represented by 3 characters as defined in [ISO 4217](http://www.xe.com/iso4217.php).
 * Dates & times are returned in UTC using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy. With requests, when no TZ is supplied, the configured TZ of the authenticated user is used.
 * Amounts are always in cents with no decimals unless otherwise stated.

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -40,6 +40,8 @@ info:
 
     * Data is sent and received as JSON.
 
+    * Clients should include the `Accepts: application/json` header in their requests.
+
     * Currencies are represented by 3 characters as defined in [ISO
     4217](http://www.xe.com/iso4217.php).
 


### PR DESCRIPTION
[Asana Job](https://app.asana.com/0/1149475516709209/1150580884117170)

Added a note  in conventions about setting the `Accepts` header.

The API will soon default to `application/json` if no `Accepts` header is specified but adding a note that they should set it correctly should hopefully avoid them accidentally setting it incorrectly.