### PR TITLE
FINAL FINAL V6 super mega final version

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -7105,7 +7105,7 @@ func main() {
 |body|body|[MakeAPaymentRequest](#schemamakeapaymentrequest)|true|No description|
 |» description|body|string|true|User description. Only visible to the payer|
 |» matures_at|body|string|true|Date & time in UTC ISO8601 the Payment should be processed. (Can not be earlier than the start of current day)|
-|» your_bank_account_id|body|string|false|Specify where we should settle the funds for this transaction. If omitted, your primary bank account will be used.|
+|» your_bank_account_id|body|string|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |» payouts|body|[[Payout](#schemapayout)]|true|One or many Payouts|
 |»» Payout|body|[Payout](#schemapayout)|false|The actual Payout|
 |»»» amount|body|number|true|Amount in cents to pay the recipient|
@@ -8140,7 +8140,7 @@ Certain rules apply to the issuance of a refund:
 |body|body|[IssueARefundRequest](#schemaissuearefundrequest)|true|No description|
 |» amount|body|number|true|Amount in cents refund|
 |» reason|body|string|false|Reason for the refund. Visible to both parties.|
-|» your_bank_account_id|body|string|false|Specify where we should settle the funds for this transaction. If omitted, your primary bank account will be used.|
+|» your_bank_account_id|body|string|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Split customisations.|
 
 > Example responses
@@ -11065,7 +11065,7 @@ func main() {
 |---|---|---|---|
 |description|string|true|User description. Only visible to the payer|
 |matures_at|string|true|Date & time in UTC ISO8601 the Payment should be processed. (Can not be earlier than the start of current day)|
-|your_bank_account_id|string|false|Specify where we should settle the funds for this transaction. If omitted, your primary bank account will be used.|
+|your_bank_account_id|string|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |payouts|[[Payout](#schemapayout)]|true|One or many Payouts|
 |metadata|[Metadata](#schemametadata)|false|No description|
 
@@ -11741,7 +11741,7 @@ func main() {
 |---|---|---|---|
 |amount|number|true|Amount in cents refund|
 |reason|string|false|Reason for the refund. Visible to both parties.|
-|your_bank_account_id|string|false|Specify where we should settle the funds for this transaction. If omitted, your primary bank account will be used.|
+|your_bank_account_id|string|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |metadata|[Metadata](#schemametadata)|false|No description|
 
 ## IssueARefundResponse

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4142,7 +4142,7 @@ components:
           example: '9/13/2016 12:00:00 AM'
         your_bank_account_id:
           type: string
-          description: Specify where we should settle the funds for this transaction. If omitted, your primary bank account will be used.
+          description: Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.
           style: form
           schema:
             type: string
@@ -4694,7 +4694,7 @@ components:
           example: Because reason
         your_bank_account_id:
           type: string
-          description: Specify where we should settle the funds for this transaction. If omitted, your primary bank account will be used.
+          description: Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.
           style: form
           schema:
             type: string


### PR DESCRIPTION
## 💡 Why

[Asana Card](https://app.asana.com/0/1173969342877601/1184208940105619/f)

Need to fix the wording for usage of `your_bank_account_id` between Payment / Payment Requests and Refunds.

## 📝 What

```
Payments - take
Payment request - settle
Refund - take
```

## 🔍 QA
[Briefly outline the QA steps you have undertaken. Include steps to replicate testing for others.]

- [x] QA'd this PR myself
- [ ] Reviewed this PR myself
- [x] Changes are Blue-Green friendly
- [x] Tested on Sandbox data
- [ ] Tested on Production data

## 📣 Final Checklist

- [x] Updated the relevant documentation
- [ ] Raised new Asana cards from the discussions in this PR 
- [ ] Added appropriate comments to my code where the code is not easily understood (context and why)
- [ ] Production & Sandbox environments are configured