### PR TITLE
Add bank account titles

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -2436,14 +2436,16 @@ By default, all Bank Accounts will be returned. There can currently be only 1 ac
       "branch_code": "493192",
       "bank_name": "National Australia Bank",
       "account_number": "3993013",
-      "status": "active"
+      "status": "active",
+      "title": "AU.493192.3993013"
     },
     {
       "id": "56df206a-aaff-471a-b075-11882bc8906a",
       "branch_code": "302193",
       "bank_name": "National Australia Bank",
       "account_number": "119302",
-      "status": "active"
+      "status": "active",
+      "title": "Trust Account"
     }
   ]
 }
@@ -10352,14 +10354,16 @@ func main() {
       "branch_code": "493192",
       "bank_name": "National Australia Bank",
       "account_number": "3993013",
-      "status": "active"
+      "status": "active",
+      "title": "AU.493192.3993013"
     },
     {
       "id": "56df206a-aaff-471a-b075-11882bc8906a",
       "branch_code": "302193",
       "bank_name": "National Australia Bank",
       "account_number": "119302",
-      "status": "active"
+      "status": "active",
+      "title": "Trust Account"
     }
   ]
 }

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -3636,11 +3636,13 @@ components:
             bank_name: National Australia Bank
             account_number: '3993013'
             status: active
+            title: 'AU.493192.3993013'
           - id: 56df206a-aaff-471a-b075-11882bc8906a
             branch_code: '302193'
             bank_name: National Australia Bank
             account_number: '119302'
             status: active
+            title: 'Trust Account'
     ListAllBankConnectionsResponse:
       title: List all Bank Connections (response)
       required:


### PR DESCRIPTION
We recently added titles to bank accounts in the API (https://github.com/splitpayments/split/pull/4022). 

By default the title is a formatted version of the country, branch code & account number. It can also be a nickname if the either the user or split has assigned one.

## Before
![Screenshot from 2020-07-23 16-24-05](https://user-images.githubusercontent.com/125175/88257756-d5920780-cd01-11ea-9c25-a54dfc8df284.png)

## After
![Screenshot from 2020-07-23 16-22-39](https://user-images.githubusercontent.com/125175/88257766-dcb91580-cd01-11ea-9804-f2563d7a9814.png)
