### PR TITLE
Add documentation for simulating PayID payments

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3286,7 +3286,7 @@ Use this endpoint when you want to pay somebody.
 |---|---|---|---|
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|[AddAnAnyoneContactResponse](#schemaaddananyonecontactresponse)|
 
-## Add a receivable Contact
+## Add a Receivable Contact
 
 <a id="opIdAddAReceivableContact"></a>
 
@@ -3467,7 +3467,7 @@ Receive funds from a Contact by allowing them to pay to a personalised PayID or 
 }
 ```
 
-<h3 id="Add-a-receivable-Contact-parameters" class="parameters">Parameters</h3>
+<h3 id="Add-a-Receivable-Contact-parameters" class="parameters">Parameters</h3>
 
 |Parameter|In|Type|Required|Description|
 |---|---|---|---|---|
@@ -3518,7 +3518,7 @@ Receive funds from a Contact by allowing them to pay to a personalised PayID or 
 }
 ```
 
-<h3 id="Add a receivable Contact-responses">Responses</h3>
+<h3 id="Add a Receivable Contact-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
@@ -8966,7 +8966,7 @@ Get a single Refund by its reference
 
 <h1 id="Split-API-Sandbox-Only">Sandbox Only</h1>
 
-Special testing endpoints that only exist in the Sandbox environment.
+Special testing endpoints that only exist in the sandbox environment.
 
 ## Simulate incoming PayID payment
 
@@ -9125,7 +9125,7 @@ func main() {
 
 `POST /simulate/incoming_payid_payment`
 
-Simulate receiving a real time PayID payment from one of your receivable contacts.
+Simulate receiving a real time PayID payment from one of your Receivable Contacts.
 
 > Body parameter
 
@@ -9141,7 +9141,7 @@ Simulate receiving a real time PayID payment from one of your receivable contact
 |Parameter|In|Type|Required|Description|
 |---|---|---|---|---|
 |body|body|[SimulateIncomingPayIDPaymentRequest](#schemasimulateincomingpayidpaymentrequest)|true|No description|
-|» payid_email|body|string|true|Receivable contact PayID email (256 max. characters)|
+|» payid_email|body|string|true|Receivable Contact PayID email (Min: 6 - Max: 256)|
 |» amount|body|number|true|Amount in cents (Min: 1 - Max: 99999999999)|
 
 > Example responses
@@ -11208,7 +11208,7 @@ func main() {
 
 ### Properties
 
-*Add a receivable Contact (request)*
+*Add a Receivable Contact (request)*
 
 |Name|Type|Required|Description|
 |---|---|---|---|
@@ -11260,7 +11260,7 @@ func main() {
 
 ### Properties
 
-*Add a receivable Contact (response)*
+*Add a Receivable Contact (response)*
 
 |Name|Type|Required|Description|
 |---|---|---|---|
@@ -12953,7 +12953,7 @@ func main() {
 
 |Name|Type|Required|Description|
 |---|---|---|---|
-|payid_email|string|true|Receivable contact PayID email (256 max. characters)|
+|payid_email|string|true|Receivable Contact PayID email (Min: 6 - Max: 256)|
 |amount|number|true|Amount in cents (Min: 1 - Max: 99999999999)|
 
 ## SimulateIncomingPayIDPaymentResponse
@@ -12976,6 +12976,6 @@ func main() {
 |---|---|---|---|
 |data|object|true|No description|
 |» id|string(uuid)|true|A unique ID which can be provided to Split for debugging purposes|
-|» payid_email|string|true|The PayID email value provided (256 max. characters)|
+|» payid_email|string|true|The PayID email value provided (Min: 6 - Max: 256)|
 |» amount|number|true|The amount value provided (Min: 1 - Max: 99999999999)|
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3451,7 +3451,7 @@ func main() {
 Receive funds from a Contact by allowing them to pay to a personalised PayID or account number. Perfect for reconciling incoming funds to a customer, receiving funds instantly, eliminating human error & improving your customer's experience.
 
 <aside class="notice">When creating this type of contact, the initial response <code>payid_details.state</code> value will always be <code>pending</code>. After a few seconds, it'll transition to <code>active</code>. We suggest you use webhooks to be informed of this state change</aside>
-<aside class="notice">You can test receiving payments to a receivable contact in our Sandbox environment using the <a href="#simulate-incoming-payid-payment">PayID simulation endpoint</a>.</aside>
+<aside class="notice">You can test receiving payments to a Receivable Contact in our sandbox environment using the <a href="#simulate-incoming-payid-payment">PayID simulation endpoint</a>.</aside>
 
 > Body parameter
 
@@ -9141,8 +9141,8 @@ Simulate receiving a real time PayID payment from one of your receivable contact
 |Parameter|In|Type|Required|Description|
 |---|---|---|---|---|
 |body|body|[SimulateIncomingPayIDPaymentRequest](#schemasimulateincomingpayidpaymentrequest)|true|No description|
-|» payid_email|body|string|true|The PayID of a receivable contact you have previously created.|
-|» amount|body|number|true|Amount in cents|
+|» payid_email|body|string|true|Receivable contact PayID email (256 max. characters)|
+|» amount|body|number|true|Amount in cents (Min: 1 - Max: 99999999999)|
 
 > Example responses
 
@@ -12953,8 +12953,8 @@ func main() {
 
 |Name|Type|Required|Description|
 |---|---|---|---|
-|payid_email|string|true|The PayID of a receivable contact you have previously created.|
-|amount|number|true|Amount in cents|
+|payid_email|string|true|Receivable contact PayID email (256 max. characters)|
+|amount|number|true|Amount in cents (Min: 1 - Max: 99999999999)|
 
 ## SimulateIncomingPayIDPaymentResponse
 
@@ -12975,7 +12975,7 @@ func main() {
 |Name|Type|Required|Description|
 |---|---|---|---|
 |data|object|true|No description|
-|» id|string(uuid)|true|A unique ID which can be provided to Split for debugging purposes.|
-|» payid_email|string|true|The value provided.|
-|» amount|number|true|The value provided.|
+|» id|string(uuid)|true|A unique ID which can be provided to Split for debugging purposes|
+|» payid_email|string|true|The PayID email value provided (256 max. characters)|
+|» amount|number|true|The amount value provided (Min: 1 - Max: 99999999999)|
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3451,6 +3451,7 @@ func main() {
 Receive funds from a Contact by allowing them to pay to a personalised PayID or account number. Perfect for reconciling incoming funds to a customer, receiving funds instantly, eliminating human error & improving your customer's experience.
 
 <aside class="notice">When creating this type of contact, the initial response <code>payid_details.state</code> value will always be <code>pending</code>. After a few seconds, it'll transition to <code>active</code>. We suggest you use webhooks to be informed of this state change</aside>
+<aside class="notice">You can test receiving payments to a receivable contact in our Sandbox environment using the <a href="#simulate-incoming-payid-payment">PayID simulation endpoint</a>.</aside>
 
 > Body parameter
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -8963,6 +8963,206 @@ Get a single Refund by its reference
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[RetrieveARefundResponse](#schemaretrievearefundresponse)|
 
+<h1 id="Split-API-Sandbox-Only">Sandbox Only</h1>
+
+Special testing endpoints that only exist in the Sandbox environment.
+
+## Simulate incoming PayID payment
+
+<a id="opIdSimulateIncomingPayIDPayment"></a>
+
+> Code samples
+
+```shell
+curl --request POST \
+  --url https://api.sandbox.split.cash/simulate/incoming_payid_payment \
+  --header 'accept: application/json' \
+  --header 'authorization: Bearer {access-token}' \
+  --header 'content-type: application/json' \
+  --data '{"payid_email":"incoming@split.cash","amount":10000}'
+```
+
+```ruby
+require 'uri'
+require 'net/http'
+
+url = URI("https://api.sandbox.split.cash/simulate/incoming_payid_payment")
+
+http = Net::HTTP.new(url.host, url.port)
+http.use_ssl = true
+http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+request = Net::HTTP::Post.new(url)
+request["content-type"] = 'application/json'
+request["accept"] = 'application/json'
+request["authorization"] = 'Bearer {access-token}'
+request.body = "{\"payid_email\":\"incoming@split.cash\",\"amount\":10000}"
+
+response = http.request(request)
+puts response.read_body
+```
+
+```javascript--node
+var http = require("https");
+
+var options = {
+  "method": "POST",
+  "hostname": "api.sandbox.split.cash",
+  "port": null,
+  "path": "/simulate/incoming_payid_payment",
+  "headers": {
+    "content-type": "application/json",
+    "accept": "application/json",
+    "authorization": "Bearer {access-token}"
+  }
+};
+
+var req = http.request(options, function (res) {
+  var chunks = [];
+
+  res.on("data", function (chunk) {
+    chunks.push(chunk);
+  });
+
+  res.on("end", function () {
+    var body = Buffer.concat(chunks);
+    console.log(body.toString());
+  });
+});
+
+req.write(JSON.stringify({ payid_email: 'incoming@split.cash', amount: 10000 }));
+req.end();
+```
+
+```python
+import http.client
+
+conn = http.client.HTTPSConnection("api.sandbox.split.cash")
+
+payload = "{\"payid_email\":\"incoming@split.cash\",\"amount\":10000}"
+
+headers = {
+    'content-type': "application/json",
+    'accept': "application/json",
+    'authorization': "Bearer {access-token}"
+    }
+
+conn.request("POST", "/simulate/incoming_payid_payment", payload, headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))
+```
+
+```java
+HttpResponse<String> response = Unirest.post("https://api.sandbox.split.cash/simulate/incoming_payid_payment")
+  .header("content-type", "application/json")
+  .header("accept", "application/json")
+  .header("authorization", "Bearer {access-token}")
+  .body("{\"payid_email\":\"incoming@split.cash\",\"amount\":10000}")
+  .asString();
+```
+
+```php
+<?php
+
+$client = new http\Client;
+$request = new http\Client\Request;
+
+$body = new http\Message\Body;
+$body->append('{"payid_email":"incoming@split.cash","amount":10000}');
+
+$request->setRequestUrl('https://api.sandbox.split.cash/simulate/incoming_payid_payment');
+$request->setRequestMethod('POST');
+$request->setBody($body);
+
+$request->setHeaders(array(
+  'authorization' => 'Bearer {access-token}',
+  'accept' => 'application/json',
+  'content-type' => 'application/json'
+));
+
+$client->enqueue($request)->send();
+$response = $client->getResponse();
+
+echo $response->getBody();
+```
+
+```go
+package main
+
+import (
+	"fmt"
+	"strings"
+	"net/http"
+	"io/ioutil"
+)
+
+func main() {
+
+	url := "https://api.sandbox.split.cash/simulate/incoming_payid_payment"
+
+	payload := strings.NewReader("{\"payid_email\":\"incoming@split.cash\",\"amount\":10000}")
+
+	req, _ := http.NewRequest("POST", url, payload)
+
+	req.Header.Add("content-type", "application/json")
+	req.Header.Add("accept", "application/json")
+	req.Header.Add("authorization", "Bearer {access-token}")
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	fmt.Println(res)
+	fmt.Println(string(body))
+
+}
+```
+
+`POST /simulate/incoming_payid_payment`
+
+Simulate receiving a real time PayID payment from one of your receivable contacts.
+
+> Body parameter
+
+```json
+{
+  "payid_email": "incoming@split.cash",
+  "amount": 10000
+}
+```
+
+<h3 id="Simulate-incoming-PayID-payment-parameters" class="parameters">Parameters</h3>
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[SimulateIncomingPayIDPaymentRequest](#schemasimulateincomingpayidpaymentrequest)|true|No description|
+|» payid_email|body|string|true|The PayID of a receivable contact you have previously created.|
+|» amount|body|number|true|Amount in cents|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "data": {
+    "id": "92c75281-5b60-489a-bd8a-e513ba9277c5",
+    "payid_email": "incoming@split.cash",
+    "amount": 10000
+  }
+}
+```
+
+<h3 id="Simulate incoming PayID payment-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|OK|[SimulateIncomingPayIDPaymentResponse](#schemasimulateincomingpayidpaymentresponse)|
+
 <h1 id="Split-API-Transactions">Transactions</h1>
 
 By default, the transactions endpoint provides a detailed look at all past, current and future debits & credits related to your account.
@@ -12736,4 +12936,45 @@ func main() {
 |Name|Type|Required|Description|
 |---|---|---|---|
 |data|object|true|No description|
+
+## SimulateIncomingPayIDPaymentRequest
+
+<a id="schemasimulateincomingpayidpaymentrequest"></a>
+
+```json
+{
+  "payid_email": "incoming@split.cash",
+  "amount": 10000
+}
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|payid_email|string|true|The PayID of a receivable contact you have previously created.|
+|amount|number|true|Amount in cents|
+
+## SimulateIncomingPayIDPaymentResponse
+
+<a id="schemasimulateincomingpayidpaymentresponse"></a>
+
+```json
+{
+  "data": {
+    "id": "92c75281-5b60-489a-bd8a-e513ba9277c5",
+    "payid_email": "incoming@split.cash",
+    "amount": 10000
+  }
+}
+```
+
+### Properties
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|data|object|true|No description|
+|» id|string(uuid)|true|A unique ID which can be provided to Split for debugging purposes.|
+|» payid_email|string|true|The value provided.|
+|» amount|number|true|The value provided.|
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -2278,6 +2278,7 @@ paths:
 
 
         <aside class="notice">When creating this type of contact, the initial response <code>payid_details.state</code> value will always be <code>pending</code>. After a few seconds, it'll transition to <code>active</code>. We suggest you use webhooks to be informed of this state change</aside>
+        <aside class="notice">You can test receiving payments to a receivable contact in our Sandbox environment using the <a href="#simulate-incoming-payid-payment">PayID simulation endpoint</a>.</aside>
       operationId: AddAReceivableContact
       parameters: []
       requestBody:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1887,8 +1887,7 @@ tags:
     description: |
       All about the currently authenticated user.
   - name: Sandbox Only
-    description: |
-      Special testing endpoints that only exist in the Sandbox environment.
+    description: Special testing endpoints that only exist in the Sandbox environment.
 paths:
   /agreements:
     post:
@@ -2278,7 +2277,7 @@ paths:
 
 
         <aside class="notice">When creating this type of contact, the initial response <code>payid_details.state</code> value will always be <code>pending</code>. After a few seconds, it'll transition to <code>active</code>. We suggest you use webhooks to be informed of this state change</aside>
-        <aside class="notice">You can test receiving payments to a receivable contact in our Sandbox environment using the <a href="#simulate-incoming-payid-payment">PayID simulation endpoint</a>.</aside>
+        <aside class="notice">You can test receiving payments to a Receivable Contact in our sandbox environment using the <a href="#simulate-incoming-payid-payment">PayID simulation endpoint</a>.</aside>
       operationId: AddAReceivableContact
       parameters: []
       requestBody:
@@ -3380,8 +3379,7 @@ paths:
       tags:
         - Sandbox Only
       summary: Simulate incoming PayID payment
-      description: >-
-        Simulate receiving a real time PayID payment from one of your receivable contacts.
+      description: Simulate receiving a real time PayID payment from one of your receivable contacts.
       operationId: SimulateIncomingPayIDPayment
       requestBody:
         description: ''
@@ -5639,10 +5637,13 @@ components:
       properties:
         payid_email:
           type: string
-          description: The PayID of a receivable contact you have previously created.
+          max: 256
+          description: Receivable contact PayID email (256 max. characters)
         amount:
           type: number
-          description: Amount in cents
+          min: 1
+          max: 99999999999
+          description: 'Amount in cents (Min: 1 - Max: 99999999999)'
       example:
         payid_email: incoming@split.cash
         amount: 10000
@@ -5661,13 +5662,17 @@ components:
             id:
               type: string
               format: uuid
-              description: A unique ID which can be provided to Split for debugging purposes.
+              description: A unique ID which can be provided to Split for debugging purposes
             payid_email:
               type: string
-              description: The value provided.
+              min: 6
+              max: 256
+              description: The PayID email value provided (256 max. characters)
             amount:
               type: number
-              description: The value provided.
+              min: 1
+              max: 99999999999
+              description: 'The amount value provided (Min: 1 - Max: 99999999999)'
       example:
         data:
           id: 92c75281-5b60-489a-bd8a-e513ba9277c5

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1887,7 +1887,7 @@ tags:
     description: |
       All about the currently authenticated user.
   - name: Sandbox Only
-    description: Special testing endpoints that only exist in the Sandbox environment.
+    description: Special testing endpoints that only exist in the sandbox environment.
 paths:
   /agreements:
     post:
@@ -2271,7 +2271,7 @@ paths:
     post:
       tags:
         - Contacts
-      summary: Add a receivable Contact
+      summary: Add a Receivable Contact
       description: |
         Receive funds from a Contact by allowing them to pay to a personalised PayID or account number. Perfect for reconciling incoming funds to a customer, receiving funds instantly, eliminating human error & improving your customer's experience.
 
@@ -3379,7 +3379,7 @@ paths:
       tags:
         - Sandbox Only
       summary: Simulate incoming PayID payment
-      description: Simulate receiving a real time PayID payment from one of your receivable contacts.
+      description: Simulate receiving a real time PayID payment from one of your Receivable Contacts.
       operationId: SimulateIncomingPayIDPayment
       requestBody:
         description: ''
@@ -3944,7 +3944,7 @@ components:
           links:
             add_bank_connection: https://go.sandbox.split.cash/invite_contact/thomas-morgan-1/1030bfef-cef5-4938-b10b-5841cafafc80
     AddAReceivableContactRequest:
-      title: Add a receivable Contact (request)
+      title: Add a Receivable Contact (request)
       required:
         - name
         - email
@@ -3970,7 +3970,7 @@ components:
           custom_key: Custom string
           another_custom_key: Maybe a URL
     AddAReceivableContactResponse:
-      title: Add a receivable Contact (response)
+      title: Add a Receivable Contact (response)
       type: object
       properties:
         data:
@@ -5637,8 +5637,9 @@ components:
       properties:
         payid_email:
           type: string
+          min: 6
           max: 256
-          description: Receivable contact PayID email (256 max. characters)
+          description: 'Receivable Contact PayID email (Min: 6 - Max: 256)'
         amount:
           type: number
           min: 1
@@ -5667,7 +5668,7 @@ components:
               type: string
               min: 6
               max: 256
-              description: The PayID email value provided (256 max. characters)
+              description: 'The PayID email value provided (Min: 6 - Max: 256)'
             amount:
               type: number
               min: 1

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1886,6 +1886,9 @@ tags:
   - name: Users
     description: |
       All about the currently authenticated user.
+  - name: Sandbox Only
+    description: |
+      Special testing endpoints that only exist in the Sandbox environment.
 paths:
   /agreements:
     post:
@@ -3371,6 +3374,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserDetailsResponse'
+  /simulate/incoming_payid_payment:
+    post:
+      tags:
+        - Sandbox Only
+      summary: Simulate incoming PayID payment
+      description: >-
+        Simulate receiving a real time PayID payment from one of your receivable contacts.
+      operationId: SimulateIncomingPayIDPayment
+      requestBody:
+        description: ''
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimulateIncomingPayIDPaymentRequest'
+        required: true
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulateIncomingPayIDPaymentResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -5605,5 +5630,47 @@ components:
             suburb: Lead
             state: NSW
             postcode: '2478'
+    SimulateIncomingPayIDPaymentRequest:
+      required:
+        - payid_email
+        - amount
+      type: object
+      properties:
+        payid_email:
+          type: string
+          description: The PayID of a receivable contact you have previously created.
+        amount:
+          type: number
+          description: Amount in cents
+      example:
+        payid_email: incoming@split.cash
+        amount: 10000
+    SimulateIncomingPayIDPaymentResponse:
+      required:
+        - data
+      type: object
+      properties:
+        data:
+          type: object
+          required:
+            - id
+            - payid_email
+            - amount
+          properties:
+            id:
+              type: string
+              format: uuid
+              description: A unique ID which can be provided to Split for debugging purposes.
+            payid_email:
+              type: string
+              description: The value provided.
+            amount:
+              type: number
+              description: The value provided.
+      example:
+        data:
+          id: 92c75281-5b60-489a-bd8a-e513ba9277c5
+          payid_email: incoming@split.cash
+          amount: 10000
 security:
   - bearerAuth: []


### PR DESCRIPTION
# What

Add documentation on how to test incoming PayID payments in Sandbox.

- Add a new `Sandbox Only` section to the sidebar.
- Add endpoint documentation for `simulate/incoming_payid_payment`.
- Add a link to the new endpoint documentation from the existing add receivable contact section.

![Screenshot from 2020-12-16 16-08-52](https://user-images.githubusercontent.com/125175/102308003-c7e36400-3fb9-11eb-8c28-7ae85ae9d967.png)
![Screenshot from 2020-12-16 16-09-27](https://user-images.githubusercontent.com/125175/102308007-c87bfa80-3fb9-11eb-827f-caea2177721d.png)
![Screenshot from 2020-12-16 16-09-47](https://user-images.githubusercontent.com/125175/102308011-c9149100-3fb9-11eb-8bd9-64f25c3a801d.png)
