### PR TITLE
Update alias_name description in two schemas

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -11355,7 +11355,7 @@ func main() {
 |»» payid_details|object|false|No description|
 |»»» alias_value|string(email)|false|The PayID email|
 |»»» alias_type|string|false|Type of PayID. Fixed to `email`|
-|»»» alias_name|string|false|The contact name|
+|»»» alias_name|string|false|Your merchant's alias_name|
 |»»» state|string|false|Pending -> Active or Failed -> Deregistered (Contact removed)|
 
 #### Enumerated Values
@@ -11663,7 +11663,7 @@ func main() {
 |»» payid_details|object|false|No description|
 |»»» alias_value|string(email)|false|The PayID email|
 |»»» alias_type|string|false|Type of PayID. Fixed to `email`|
-|»»» alias_name|string|false|The contact name|
+|»»» alias_name|string|false|Your merchant's alias_name|
 |»»» state|string|false|Pending -> Active or Failed -> Deregistered (Contact removed)|
 
 #### Enumerated Values

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4168,7 +4168,7 @@ components:
                   type: string
                   min: 3
                   max: 140
-                  description: The contact name
+                  description: Your merchant's alias_name
                 state:
                   type: string
                   description: Pending -> Active or Failed -> Deregistered (Contact removed)
@@ -4496,7 +4496,7 @@ components:
                   type: string
                   min: 3
                   max: 140
-                  description: The contact name
+                  description: Your merchant's alias_name
                 state:
                   type: string
                   description: Pending -> Active or Failed -> Deregistered (Contact removed)


### PR DESCRIPTION
Update two response schemas to show `Your merchant's alias_name` rather than `The contact name`

**Before**
![Screen Shot 2021-02-24 at 12 45 13 pm](https://user-images.githubusercontent.com/46544374/108932876-2f92eb00-769e-11eb-89d7-044ae9ec8745.png)

**After**
![Screen Shot 2021-02-24 at 12 43 25 pm](https://user-images.githubusercontent.com/46544374/108932785-0c683b80-769e-11eb-83a6-25820e90264b.png)
