### PR TITLE
Remove upstream dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  target-branch: dev
-  versioning-strategy: increase-if-necessary


### PR DESCRIPTION
When updating our repository from the upstream we inherited all the GitHub configuration files. I've already removed other files, this was forgotten.