### PR TITLE
Document optional channels param for refunds

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -10936,17 +10936,17 @@ func main() {
 |Name|Type|Required|Description|
 |---|---|---|---|
 |data|object|true|No description|
-|ref|string(uuid)|true|The Refund request reference (PRF.*) (Min: 5 - Max: 9)|
-|for_ref|string|true|The associated credit reference (C.*)|
-|debit_ref|string|true|The associated debit reference (C.*)|
-|your_bank_account_id|string|true|The source bank/float account (UUID)|
-|created_at|string(date-time)|true|The date-time when the Payment Request was created|
-|amount|integer|true|The amount value provided (Min: 1 - Max: 99999999999)|
-|channels|array|false|The requested payment channel(s) to be used, in order. (new_payments_platform, direct_entry, or both)|
-|reason|string|true|Reason for the refund|
-|contacts|object|false|No description|
-|» source_contact_id|string|false|The original 'Receivable Contact' ID (only visible when refunding Receivables)|
-|» target_contact_id|string|false|The new Contact ID receiving the funds (only visible when refunding Receivables)|
+|» ref|string(uuid)|true|The Refund request reference (PRF.*) (Min: 5 - Max: 9)|
+|» for_ref|string|true|The associated credit reference (C.*)|
+|» debit_ref|string|true|The associated debit reference (C.*)|
+|» your_bank_account_id|string|true|The source bank/float account (UUID)|
+|» created_at|string(date-time)|true|The date-time when the Payment Request was created|
+|» amount|integer|true|The amount value provided (Min: 1 - Max: 99999999999)|
+|» channels|array|false|The requested payment channel(s) to be used, in order. (new_payments_platform, direct_entry, or both)|
+|» reason|string|true|Reason for the refund|
+|» contacts|object|false|No description|
+|»» source_contact_id|string|false|The original 'Receivable Contact' ID (only visible when refunding Receivables)|
+|»» target_contact_id|string|false|The new Contact ID receiving the funds (only visible when refunding Receivables)|
 
 ## ListOutgoingRefundsResponse
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5794,7 +5794,9 @@ To enable custom payment flows, the required payment channel can be selected by 
   "data": {
     "ref": "PB.1",
     "your_bank_account_id": "83623359-e86e-440c-9780-432a3bc3626f",
-    "channels": "new_payments_platform",
+    "channels": [
+      "new_payments_platform"
+    ],
     "payouts": [
       {
         "ref": "D.1",
@@ -10354,7 +10356,9 @@ func main() {
   "data": {
     "ref": "PB.1",
     "your_bank_account_id": "83623359-e86e-440c-9780-432a3bc3626f",
-    "channels": "new_payments_platform",
+    "channels": [
+      "new_payments_platform"
+    ],
     "payouts": [
       {
         "ref": "D.1",

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -6617,7 +6617,7 @@ curl --request POST \
   --header 'accept: application/json' \
   --header 'authorization: Bearer {access-token}' \
   --header 'content-type: application/json' \
-  --data '{"amount":500,"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
+  --data '{"amount":500,"channels":["direct_entry"],"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
 ```
 
 ```ruby
@@ -6634,7 +6634,7 @@ request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/json'
 request["accept"] = 'application/json'
 request["authorization"] = 'Bearer {access-token}'
-request.body = "{\"amount\":500,\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
+request.body = "{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
 response = http.request(request)
 puts response.read_body
@@ -6670,6 +6670,7 @@ var req = http.request(options, function (res) {
 
 req.write(JSON.stringify({
   amount: 500,
+  channels: [ 'direct_entry' ],
   reason: 'Because reason',
   your_bank_account_id: '9c70871d-8e36-4c3e-8a9c-c0ee20e7c679',
   metadata: { custom_key: 'Custom string', another_custom_key: 'Maybe a URL' }
@@ -6682,7 +6683,7 @@ import http.client
 
 conn = http.client.HTTPSConnection("api.sandbox.split.cash")
 
-payload = "{\"amount\":500,\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
+payload = "{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
 headers = {
     'content-type': "application/json",
@@ -6703,7 +6704,7 @@ HttpResponse<String> response = Unirest.post("https://api.sandbox.split.cash/cre
   .header("content-type", "application/json")
   .header("accept", "application/json")
   .header("authorization", "Bearer {access-token}")
-  .body("{\"amount\":500,\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
+  .body("{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
   .asString();
 ```
 
@@ -6714,7 +6715,7 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append('{"amount":500,"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}');
+$body->append('{"amount":500,"channels":["direct_entry"],"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}');
 
 $request->setRequestUrl('https://api.sandbox.split.cash/credits/string/refunds');
 $request->setRequestMethod('POST');
@@ -6746,7 +6747,7 @@ func main() {
 
 	url := "https://api.sandbox.split.cash/credits/string/refunds"
 
-	payload := strings.NewReader("{\"amount\":500,\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
+	payload := strings.NewReader("{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
 
 	req, _ := http.NewRequest("POST", url, payload)
 
@@ -6779,6 +6780,9 @@ Certain rules apply to the issuance of a refund:
 ```json
 {
   "amount": 500,
+  "channels": [
+    "direct_entry"
+  ],
   "reason": "Because reason",
   "your_bank_account_id": "9c70871d-8e36-4c3e-8a9c-c0ee20e7c679",
   "metadata": {
@@ -10869,6 +10873,9 @@ func main() {
 ```json
 {
   "amount": 500,
+  "channels": [
+    "direct_entry"
+  ],
   "reason": "Because reason",
   "your_bank_account_id": "9c70871d-8e36-4c3e-8a9c-c0ee20e7c679",
   "metadata": {

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5566,7 +5566,7 @@ curl --request POST \
   --header 'accept: application/json' \
   --header 'authorization: Bearer {access-token}' \
   --header 'content-type: application/json' \
-  --data '{"description":"The SuperPackage","matures_at":"2021-06-13T00:00:00Z","your_bank_account_id":"83623359-e86e-440c-9780-432a3bc3626f","channels":"new_payments_platform","payouts":[{"amount":30000,"description":"A tandem skydive jump SB23094","recipient_contact_id":"48b89364-1577-4c81-ba02-96705895d457","metadata":{"invoice_ref":"BILL-0001","invoice_id":"c80a9958-e805-47c0-ac2a-c947d7fd778d","custom_key":"Custom string","another_custom_key":"Maybe a URL"}}],"metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
+  --data '{"description":"The SuperPackage","matures_at":"2021-06-13T00:00:00Z","your_bank_account_id":"83623359-e86e-440c-9780-432a3bc3626f","channels":["new_payments_platform"],"payouts":[{"amount":30000,"description":"A tandem skydive jump SB23094","recipient_contact_id":"48b89364-1577-4c81-ba02-96705895d457","metadata":{"invoice_ref":"BILL-0001","invoice_id":"c80a9958-e805-47c0-ac2a-c947d7fd778d","custom_key":"Custom string","another_custom_key":"Maybe a URL"}}],"metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
 ```
 
 ```ruby
@@ -5583,7 +5583,7 @@ request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/json'
 request["accept"] = 'application/json'
 request["authorization"] = 'Bearer {access-token}'
-request.body = "{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":\"new_payments_platform\",\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
+request.body = "{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":[\"new_payments_platform\"],\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
 response = http.request(request)
 puts response.read_body
@@ -5621,7 +5621,7 @@ req.write(JSON.stringify({
   description: 'The SuperPackage',
   matures_at: '2021-06-13T00:00:00Z',
   your_bank_account_id: '83623359-e86e-440c-9780-432a3bc3626f',
-  channels: 'new_payments_platform',
+  channels: [ 'new_payments_platform' ],
   payouts: [
     {
       amount: 30000,
@@ -5645,7 +5645,7 @@ import http.client
 
 conn = http.client.HTTPSConnection("api.sandbox.split.cash")
 
-payload = "{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":\"new_payments_platform\",\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
+payload = "{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":[\"new_payments_platform\"],\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
 headers = {
     'content-type': "application/json",
@@ -5666,7 +5666,7 @@ HttpResponse<String> response = Unirest.post("https://api.sandbox.split.cash/pay
   .header("content-type", "application/json")
   .header("accept", "application/json")
   .header("authorization", "Bearer {access-token}")
-  .body("{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":\"new_payments_platform\",\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
+  .body("{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":[\"new_payments_platform\"],\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
   .asString();
 ```
 
@@ -5677,7 +5677,7 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append('{"description":"The SuperPackage","matures_at":"2021-06-13T00:00:00Z","your_bank_account_id":"83623359-e86e-440c-9780-432a3bc3626f","channels":"new_payments_platform","payouts":[{"amount":30000,"description":"A tandem skydive jump SB23094","recipient_contact_id":"48b89364-1577-4c81-ba02-96705895d457","metadata":{"invoice_ref":"BILL-0001","invoice_id":"c80a9958-e805-47c0-ac2a-c947d7fd778d","custom_key":"Custom string","another_custom_key":"Maybe a URL"}}],"metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}');
+$body->append('{"description":"The SuperPackage","matures_at":"2021-06-13T00:00:00Z","your_bank_account_id":"83623359-e86e-440c-9780-432a3bc3626f","channels":["new_payments_platform"],"payouts":[{"amount":30000,"description":"A tandem skydive jump SB23094","recipient_contact_id":"48b89364-1577-4c81-ba02-96705895d457","metadata":{"invoice_ref":"BILL-0001","invoice_id":"c80a9958-e805-47c0-ac2a-c947d7fd778d","custom_key":"Custom string","another_custom_key":"Maybe a URL"}}],"metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}');
 
 $request->setRequestUrl('https://api.sandbox.split.cash/payments');
 $request->setRequestMethod('POST');
@@ -5709,7 +5709,7 @@ func main() {
 
 	url := "https://api.sandbox.split.cash/payments"
 
-	payload := strings.NewReader("{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":\"new_payments_platform\",\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
+	payload := strings.NewReader("{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":[\"new_payments_platform\"],\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
 
 	req, _ := http.NewRequest("POST", url, payload)
 
@@ -5745,7 +5745,9 @@ To enable custom payment flows, the required payment channel can be selected by 
   "description": "The SuperPackage",
   "matures_at": "2021-06-13T00:00:00Z",
   "your_bank_account_id": "83623359-e86e-440c-9780-432a3bc3626f",
-  "channels": "new_payments_platform",
+  "channels": [
+    "new_payments_platform"
+  ],
   "payouts": [
     {
       "amount": 30000,
@@ -10248,7 +10250,9 @@ func main() {
   "description": "The SuperPackage",
   "matures_at": "2021-06-13T00:00:00Z",
   "your_bank_account_id": "83623359-e86e-440c-9780-432a3bc3626f",
-  "channels": "new_payments_platform",
+  "channels": [
+    "new_payments_platform"
+  ],
   "payouts": [
     {
       "amount": 30000,

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -6791,6 +6791,7 @@ Certain rules apply to the issuance of a refund:
 |credit_ref|path|string|true|The credit reference number e.g C.625v|
 |body|body|[IssueARefundRequest](#schemaissuearefundrequest)|true|No description|
 |» amount|body|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|
+|» channels|body|array|false|Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)|
 |» reason|body|string|false|Reason for the refund. First 9 characters are visible to both parties.|
 |» your_bank_account_id|body|string(uuid)|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Split customisations.|
@@ -10876,6 +10877,7 @@ func main() {
 |Name|Type|Required|Description|
 |---|---|---|---|
 |amount|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|
+|channels|array|false|Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)|
 |reason|string|false|Reason for the refund. First 9 characters are visible to both parties.|
 |your_bank_account_id|string(uuid)|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |metadata|[Metadata](#schemametadata)|false|No description|

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -6817,6 +6817,9 @@ Certain rules apply to the issuance of a refund:
     "your_bank_account_id": "9c70871d-8e36-4c3e-8a9c-c0ee20e7c679",
     "created_at": "2021-06-01T07:20:24Z",
     "amount": 500,
+    "channels": [
+      "direct_entry"
+    ],
     "reason": "Subscription refund",
     "contacts": {
       "source_contact_id": "194b0237-6c2c-4705-b4fb-308274b14eda",
@@ -10910,6 +10913,9 @@ func main() {
     "your_bank_account_id": "9c70871d-8e36-4c3e-8a9c-c0ee20e7c679",
     "created_at": "2021-06-01T07:20:24Z",
     "amount": 500,
+    "channels": [
+      "direct_entry"
+    ],
     "reason": "Subscription refund",
     "contacts": {
       "source_contact_id": "194b0237-6c2c-4705-b4fb-308274b14eda",
@@ -10936,6 +10942,7 @@ func main() {
 |your_bank_account_id|string|true|The source bank/float account (UUID)|
 |created_at|string(date-time)|true|The date-time when the Payment Request was created|
 |amount|integer|true|The amount value provided (Min: 1 - Max: 99999999999)|
+|channels|array|false|The requested payment channel(s) to be used, in order. (new_payments_platform, direct_entry, or both)|
 |reason|string|true|Reason for the refund|
 |contacts|object|false|No description|
 |» source_contact_id|string|false|The original 'Receivable Contact' ID (only visible when refunding Receivables)|

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4278,7 +4278,7 @@ components:
         description: The SuperPackage
         matures_at: '2021-06-13T00:00:00Z'
         your_bank_account_id: 83623359-e86e-440c-9780-432a3bc3626f
-        channels: new_payments_platform
+        channels: ["new_payments_platform"]
         payouts:
           - amount: 30000
             description: A tandem skydive jump SB23094

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4343,7 +4343,7 @@ components:
         data:
           ref: PB.1
           your_bank_account_id: 83623359-e86e-440c-9780-432a3bc3626f
-          channels: new_payments_platform
+          channels: ["new_payments_platform"]
           payouts:
             - ref: D.1
               recipient_contact_id: 48b89364-1577-4c81-ba02-96705895d457

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -5023,6 +5023,9 @@ components:
           max: 99999999999
           description: 'Amount in cents refund (Min: 1 - Max: 99999999999)'
           example: 500
+        channels:
+          description: Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)
+          type: array
         reason:
           type: string
           description: Reason for the refund. First 9 characters are visible to both parties.

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -5038,6 +5038,7 @@ components:
           $ref: '#/components/schemas/Metadata'
       example:
         amount: 500
+        channels: ["direct_entry"]
         reason: Because reason
         your_bank_account_id: 9c70871d-8e36-4c3e-8a9c-c0ee20e7c679
         metadata:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -5080,6 +5080,9 @@ components:
         amount:
           type: integer
           description: 'The amount value provided (Min: 1 - Max: 99999999999)'
+        channels:
+          type: array
+          description: The requested payment channel(s) to be used, in order. (new_payments_platform, direct_entry, or both)
         reason:
           type: string
           description: Reason for the refund
@@ -5100,6 +5103,7 @@ components:
           your_bank_account_id: 9c70871d-8e36-4c3e-8a9c-c0ee20e7c679
           created_at: '2021-06-01T07:20:24Z'
           amount: 500
+          channels: ["direct_entry"]
           reason: Subscription refund
           contacts:
             source_contact_id: 194b0237-6c2c-4705-b4fb-308274b14eda

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -5049,52 +5049,54 @@ components:
       type: object
       required:
         - data
-        - ref
-        - for_ref
-        - debit_ref
-        - your_bank_account_id
-        - created_at
-        - amount
-        - reason
       properties:
         data:
           type: object
-        ref:
-          type: string
-          format: uuid
-          description: 'The Refund request reference (PRF.*) (Min: 5 - Max: 9)'
-        for_ref:
-          type: string
-          description: 'The associated credit reference (C.*)'
-        debit_ref:
-          type: string
-          description: 'The associated debit reference (C.*)'
-        your_bank_account_id:
-          type: string
-          description: 'The source bank/float account (UUID)'
-        created_at:
-          type: string
-          format: date-time
-          description: The date-time when the Payment Request was created
-          example: '2021-06-01T08:30:12Z'
-        amount:
-          type: integer
-          description: 'The amount value provided (Min: 1 - Max: 99999999999)'
-        channels:
-          type: array
-          description: The requested payment channel(s) to be used, in order. (new_payments_platform, direct_entry, or both)
-        reason:
-          type: string
-          description: Reason for the refund
-        contacts:
-          type: object
+          required:
+            - ref
+            - for_ref
+            - debit_ref
+            - your_bank_account_id
+            - created_at
+            - amount
+            - reason
           properties:
-            source_contact_id:
+            ref:
               type: string
-              description: The original 'Receivable Contact' ID (only visible when refunding Receivables)
-            target_contact_id:
+              format: uuid
+              description: 'The Refund request reference (PRF.*) (Min: 5 - Max: 9)'
+            for_ref:
               type: string
-              description: The new Contact ID receiving the funds (only visible when refunding Receivables)
+              description: 'The associated credit reference (C.*)'
+            debit_ref:
+              type: string
+              description: 'The associated debit reference (C.*)'
+            your_bank_account_id:
+              type: string
+              description: 'The source bank/float account (UUID)'
+            created_at:
+              type: string
+              format: date-time
+              description: The date-time when the Payment Request was created
+              example: '2021-06-01T08:30:12Z'
+            amount:
+              type: integer
+              description: 'The amount value provided (Min: 1 - Max: 99999999999)'
+            channels:
+              type: array
+              description: The requested payment channel(s) to be used, in order. (new_payments_platform, direct_entry, or both)
+            reason:
+              type: string
+              description: Reason for the refund
+            contacts:
+              type: object
+              properties:
+                source_contact_id:
+                  type: string
+                  description: The original 'Receivable Contact' ID (only visible when refunding Receivables)
+                target_contact_id:
+                  type: string
+                  description: The new Contact ID receiving the funds (only visible when refunding Receivables)
       example:
         data:
           ref: PRF.7f4


### PR DESCRIPTION
1. Add optional `channels` to `IssueARefundRequest`:
![image](https://user-images.githubusercontent.com/9605/126912019-203aaf53-8c35-4df1-aa6b-6a59cb17f8a2.png)
1. Add optional `channels` to `IssueARefundResponse`:
![image](https://user-images.githubusercontent.com/9605/126912008-070c7eef-aed3-4a12-a17a-04d3297d400f.png)
1. MakeAPaymentRequest/MakeAPaymentResponse `channels` examples should be arrays. 