### PR TITLE
Ensure GH pages CNAME is docs.zepto.money

### DIFF
--- a/source/CNAME
+++ b/source/CNAME
@@ -1,1 +1,1 @@
-docs.split.cash
+docs.zepto.money


### PR DESCRIPTION
This takes precedence over the GH Pages custom domain value configured in web UI.