### PR TITLE
Ensure Changelog rendered as list

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -928,6 +928,7 @@ To protect against timing attacks, use a constant-time string comparison to comp
 
 # Changelog
 We take backwards compatibility seriously. The following list contains backwards compatible changes:
+
 - **2021-09-08** - Added Webhooks and Webhook Delivery endpoints
 - **2021-08-31** - Added PayID pool references to */contacts/receivable* and */bank_accounts* endpoints
 - **2021-07-01** - Added $1.65 amount for Sandbox simulated failures and minor tweaks

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1497,6 +1497,7 @@ info:
 
     We take backwards compatibility seriously. The following list contains backwards compatible changes:
 
+
     - **2021-09-08** - Added Webhooks and Webhook Delivery endpoints
 
     - **2021-08-31** - Added PayID pool references to */contacts/receivable* and */bank_accounts* endpoints


### PR DESCRIPTION
The leading space in the source yaml for the changelog list was removed causing the generated markdown to render as a block of text instead of a list.

## 🏚 Before
<img width="955" alt="Screen Shot 2021-09-13 at 11 17 32 am" src="https://user-images.githubusercontent.com/4829526/133010721-dfd3ff7a-4f53-4a95-90c4-1e4d7e895ac0.png">

## 🏡 After
<img width="956" alt="Screen Shot 2021-09-13 at 11 16 59 am" src="https://user-images.githubusercontent.com/4829526/133010767-9cef873c-392f-498d-9235-641aca9ba2e4.png">
