### PR TITLE
Update docs to include idempotency hints for relevant requests

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -383,7 +383,7 @@ Example flow embedding an [Open Agreement link](https://help.split.cash/agreemen
 ```
 
 The Zepto API supports idempotency for safely retrying requests without accidentally performing the same operation twice.
-For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is a network connection error, you can retry the Payment with the same idempotency key to guarantee that only a single Payment is created.
+For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is a network connection error, you can retry the Payment with the same idempotency key to guarantee that only a single Payment is created.  In case an idempotency key is not supplied and a Payment is retried,  we would treat this as two different payments being made.
 
 To perform an idempotent request, provide an additional `Idempotency-Key: <key>` header to the request.
 You can pass any value as the key but we suggest that you use [V4 UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
@@ -396,7 +396,7 @@ Keys expire after 24 hours. If there is a subsequent request with the same idemp
 * Endpoints that use the `GET` or `DELETE` actions are idempotent by nature.
 * A request that quickly follows another with the same idempotency key may return with `503 Service Unavailable`. If so, retry the request after the number of seconds specified in the `Retry-After` response header.
 
-Currently the following `POST` requests can be made idempotent:
+Currently the following `POST` requests can be made idempotent.  We **strongly recommend** sending a unique `Idempotency-Key` header  when making those requests to allow for safe retries:
 
 * [Request Payment](/#request-payment)
 * [Make a Payment](/#make-a-payment)
@@ -4934,7 +4934,7 @@ func main() {
 
 `POST /payment_requests`
 
-<aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 
@@ -5961,7 +5961,7 @@ To enable custom payment flows, the required payment channel can be selected by 
   <li>["direct_entry"] - for slower traditional payments</li>
   <li>["new_payments_platform", "direct_entry"] - enables automatic channel switching if a payment fails on the NPP</li>
 </ul>
-<aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 
@@ -6994,7 +6994,7 @@ Certain rules apply to the issuance of a refund:
   <li>Many refunds may be created against the original Payment Request</li>
   <li>The total refunded amount must not exceed the original value</li>
 </ul>
-<aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -4782,6 +4782,7 @@ curl --request POST \
   --header 'accept: application/json' \
   --header 'authorization: Bearer {access-token}' \
   --header 'content-type: application/json' \
+  --header 'idempotency-key: {unique-uuid-per-payment-request}' \
   --data '{"description":"Visible to both initiator and authoriser","matures_at":"2016-12-19T02:10:56.000Z","amount":99000,"authoriser_contact_id":"de86472c-c027-4735-a6a7-234366a27fc7","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
 ```
 
@@ -4798,6 +4799,7 @@ http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/json'
 request["accept"] = 'application/json'
+request["idempotency-key"] = '{unique-uuid-per-payment-request}'
 request["authorization"] = 'Bearer {access-token}'
 request.body = "{\"description\":\"Visible to both initiator and authoriser\",\"matures_at\":\"2016-12-19T02:10:56.000Z\",\"amount\":99000,\"authoriser_contact_id\":\"de86472c-c027-4735-a6a7-234366a27fc7\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
@@ -4816,6 +4818,7 @@ var options = {
   "headers": {
     "content-type": "application/json",
     "accept": "application/json",
+    "idempotency-key": "{unique-uuid-per-payment-request}",
     "authorization": "Bearer {access-token}"
   }
 };
@@ -4854,6 +4857,7 @@ payload = "{\"description\":\"Visible to both initiator and authoriser\",\"matur
 headers = {
     'content-type': "application/json",
     'accept': "application/json",
+    'idempotency-key': "{unique-uuid-per-payment-request}",
     'authorization': "Bearer {access-token}"
     }
 
@@ -4869,6 +4873,7 @@ print(data.decode("utf-8"))
 HttpResponse<String> response = Unirest.post("https://api.sandbox.split.cash/payment_requests")
   .header("content-type", "application/json")
   .header("accept", "application/json")
+  .header("idempotency-key", "{unique-uuid-per-payment-request}")
   .header("authorization", "Bearer {access-token}")
   .body("{\"description\":\"Visible to both initiator and authoriser\",\"matures_at\":\"2016-12-19T02:10:56.000Z\",\"amount\":99000,\"authoriser_contact_id\":\"de86472c-c027-4735-a6a7-234366a27fc7\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
   .asString();
@@ -4889,6 +4894,7 @@ $request->setBody($body);
 
 $request->setHeaders(array(
   'authorization' => 'Bearer {access-token}',
+  'idempotency-key' => '{unique-uuid-per-payment-request}',
   'accept' => 'application/json',
   'content-type' => 'application/json'
 ));
@@ -4919,6 +4925,7 @@ func main() {
 
 	req.Header.Add("content-type", "application/json")
 	req.Header.Add("accept", "application/json")
+	req.Header.Add("idempotency-key", "{unique-uuid-per-payment-request}")
 	req.Header.Add("authorization", "Bearer {access-token}")
 
 	res, _ := http.DefaultClient.Do(req)
@@ -4956,6 +4963,7 @@ func main() {
 
 |Parameter|In|Type|Required|Description|
 |---|---|---|---|---|
+|Idempotency-Key|header|string|false|Idempotency key to support safe retries for 24h|
 |body|body|[MakeAPaymentRequestRequest](#schemamakeapaymentrequestrequest)|true|No description|
 |» description|body|string|true|Description visible to the initiator (payee). The first 9 characters supplied will be visible to the authoriser (payer)|
 |» matures_at|body|string(date-time)|true|Date & time in UTC ISO8601 that the Payment will be processed if the request is approved. (If the request is approved after this point in time, it will be processed straight away)|
@@ -5790,6 +5798,7 @@ curl --request POST \
   --header 'accept: application/json' \
   --header 'authorization: Bearer {access-token}' \
   --header 'content-type: application/json' \
+  --header 'idempotency-key: {unique-uuid-per-payment}' \
   --data '{"description":"The SuperPackage","matures_at":"2021-06-13T00:00:00Z","your_bank_account_id":"83623359-e86e-440c-9780-432a3bc3626f","channels":["new_payments_platform"],"payouts":[{"amount":30000,"description":"A tandem skydive jump SB23094","recipient_contact_id":"48b89364-1577-4c81-ba02-96705895d457","metadata":{"invoice_ref":"BILL-0001","invoice_id":"c80a9958-e805-47c0-ac2a-c947d7fd778d","custom_key":"Custom string","another_custom_key":"Maybe a URL"}}],"metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
 ```
 
@@ -5806,6 +5815,7 @@ http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/json'
 request["accept"] = 'application/json'
+request["idempotency-key"] = '{unique-uuid-per-payment}'
 request["authorization"] = 'Bearer {access-token}'
 request.body = "{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":[\"new_payments_platform\"],\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
@@ -5824,6 +5834,7 @@ var options = {
   "headers": {
     "content-type": "application/json",
     "accept": "application/json",
+    "idempotency-key": "{unique-uuid-per-payment}",
     "authorization": "Bearer {access-token}"
   }
 };
@@ -5874,6 +5885,7 @@ payload = "{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:
 headers = {
     'content-type': "application/json",
     'accept': "application/json",
+    'idempotency-key': "{unique-uuid-per-payment}",
     'authorization': "Bearer {access-token}"
     }
 
@@ -5889,6 +5901,7 @@ print(data.decode("utf-8"))
 HttpResponse<String> response = Unirest.post("https://api.sandbox.split.cash/payments")
   .header("content-type", "application/json")
   .header("accept", "application/json")
+  .header("idempotency-key", "{unique-uuid-per-payment}")
   .header("authorization", "Bearer {access-token}")
   .body("{\"description\":\"The SuperPackage\",\"matures_at\":\"2021-06-13T00:00:00Z\",\"your_bank_account_id\":\"83623359-e86e-440c-9780-432a3bc3626f\",\"channels\":[\"new_payments_platform\"],\"payouts\":[{\"amount\":30000,\"description\":\"A tandem skydive jump SB23094\",\"recipient_contact_id\":\"48b89364-1577-4c81-ba02-96705895d457\",\"metadata\":{\"invoice_ref\":\"BILL-0001\",\"invoice_id\":\"c80a9958-e805-47c0-ac2a-c947d7fd778d\",\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}],\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
   .asString();
@@ -5909,6 +5922,7 @@ $request->setBody($body);
 
 $request->setHeaders(array(
   'authorization' => 'Bearer {access-token}',
+  'idempotency-key' => '{unique-uuid-per-payment}',
   'accept' => 'application/json',
   'content-type' => 'application/json'
 ));
@@ -5939,6 +5953,7 @@ func main() {
 
 	req.Header.Add("content-type", "application/json")
 	req.Header.Add("accept", "application/json")
+	req.Header.Add("idempotency-key", "{unique-uuid-per-payment}")
 	req.Header.Add("authorization", "Bearer {access-token}")
 
 	res, _ := http.DefaultClient.Do(req)
@@ -5997,6 +6012,7 @@ To enable custom payment flows, the required payment channel can be selected by 
 
 |Parameter|In|Type|Required|Description|
 |---|---|---|---|---|
+|Idempotency-Key|header|string|false|Idempotency key to support safe retries for 24h|
 |body|body|[MakeAPaymentRequest](#schemamakeapaymentrequest)|true|No description|
 |» description|body|string|true|User description. Only visible to the payer|
 |» matures_at|body|string(date-time)|true|Date & time in UTC ISO8601 the Payment should be processed. (Can not be earlier than the start of current day in Sydney AEST/AEDT)|
@@ -6837,6 +6853,7 @@ curl --request POST \
   --header 'accept: application/json' \
   --header 'authorization: Bearer {access-token}' \
   --header 'content-type: application/json' \
+  --header 'idempotency-key: {unique-uuid-per-refund}' \
   --data '{"amount":500,"channels":["direct_entry"],"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
 ```
 
@@ -6853,6 +6870,7 @@ http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/json'
 request["accept"] = 'application/json'
+request["idempotency-key"] = '{unique-uuid-per-refund}'
 request["authorization"] = 'Bearer {access-token}'
 request.body = "{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
@@ -6871,6 +6889,7 @@ var options = {
   "headers": {
     "content-type": "application/json",
     "accept": "application/json",
+    "idempotency-key": "{unique-uuid-per-refund}",
     "authorization": "Bearer {access-token}"
   }
 };
@@ -6908,6 +6927,7 @@ payload = "{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because 
 headers = {
     'content-type': "application/json",
     'accept': "application/json",
+    'idempotency-key': "{unique-uuid-per-refund}",
     'authorization': "Bearer {access-token}"
     }
 
@@ -6923,6 +6943,7 @@ print(data.decode("utf-8"))
 HttpResponse<String> response = Unirest.post("https://api.sandbox.split.cash/credits/string/refunds")
   .header("content-type", "application/json")
   .header("accept", "application/json")
+  .header("idempotency-key", "{unique-uuid-per-refund}")
   .header("authorization", "Bearer {access-token}")
   .body("{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
   .asString();
@@ -6943,6 +6964,7 @@ $request->setBody($body);
 
 $request->setHeaders(array(
   'authorization' => 'Bearer {access-token}',
+  'idempotency-key' => '{unique-uuid-per-refund}',
   'accept' => 'application/json',
   'content-type' => 'application/json'
 ));
@@ -6973,6 +6995,7 @@ func main() {
 
 	req.Header.Add("content-type", "application/json")
 	req.Header.Add("accept", "application/json")
+	req.Header.Add("idempotency-key", "{unique-uuid-per-refund}")
 	req.Header.Add("authorization", "Bearer {access-token}")
 
 	res, _ := http.DefaultClient.Do(req)
@@ -7017,6 +7040,7 @@ Certain rules apply to the issuance of a refund:
 
 |Parameter|In|Type|Required|Description|
 |---|---|---|---|---|
+|Idempotency-Key|header|string|false|Idempotency key to support safe retries for 24h|
 |credit_ref|path|string|true|The credit reference number e.g C.625v|
 |body|body|[IssueARefundRequest](#schemaissuearefundrequest)|true|No description|
 |» amount|body|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -396,6 +396,12 @@ Keys expire after 24 hours. If there is a subsequent request with the same idemp
 * Endpoints that use the `GET` or `DELETE` actions are idempotent by nature.
 * A request that quickly follows another with the same idempotency key may return with `503 Service Unavailable`. If so, retry the request after the number of seconds specified in the `Retry-After` response header.
 
+Currently the following `POST` requests can be made idempotent:
+
+* [Request Payment](/#request-payment)
+* [Make a Payment](/#make-a-payment)
+* [Issue a Refund](/#issue-a-refund)
+
 ## Error responses
 
 > Example detailed error response
@@ -4928,6 +4934,8 @@ func main() {
 
 `POST /payment_requests`
 
+<aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+
 > Body parameter
 
 ```json
@@ -5953,6 +5961,7 @@ To enable custom payment flows, the required payment channel can be selected by 
   <li>["direct_entry"] - for slower traditional payments</li>
   <li>["new_payments_platform", "direct_entry"] - enables automatic channel switching if a payment fails on the NPP</li>
 </ul>
+<aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 
@@ -6985,6 +6994,7 @@ Certain rules apply to the issuance of a refund:
   <li>Many refunds may be created against the original Payment Request</li>
   <li>The total refunded amount must not exceed the original value</li>
 </ul>
+<aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -2770,6 +2770,14 @@ paths:
 
         <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPayment
+      parameters:
+        - name: 'Idempotency-Key'
+          in: header
+          description: 'Idempotency key to support safe retries for 24h'
+          required: false
+          schema:
+            type: string
+          example: '{unique-uuid-per-payment}'
       requestBody:
         description: ''
         content:
@@ -2902,7 +2910,14 @@ paths:
       description: >
         <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPaymentRequest
-      parameters: []
+      parameters:
+        - name: 'Idempotency-Key'
+          in: header
+          description: 'Idempotency key to support safe retries for 24h'
+          required: false
+          schema:
+            type: string
+          example: '{unique-uuid-per-payment-request}'
       requestBody:
         description: ''
         content:
@@ -3040,6 +3055,13 @@ paths:
         <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: IssueARefund
       parameters:
+        - name: 'Idempotency-Key'
+          in: header
+          description: 'Idempotency key to support safe retries for 24h'
+          required: false
+          schema:
+            type: string
+          example: '{unique-uuid-per-refund}'
         - name: credit_ref
           in: path
           description: 'The credit reference number e.g C.625v'

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -549,7 +549,9 @@ info:
 
     For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is
     a network connection error, you can retry the Payment with the same
-    idempotency key to guarantee that only a single Payment is created.
+    idempotency key to guarantee that only a single Payment is created. 
+    In case an idempotency key is not supplied and a Payment is retried, 
+    we would treat this as two different payments being made.
 
 
     To perform an idempotent request, provide an additional `Idempotency-Key:
@@ -579,7 +581,9 @@ info:
     specified in the `Retry-After` response header.
 
 
-    Currently the following `POST` requests can be made idempotent:
+    Currently the following `POST` requests can be made idempotent. 
+    We **strongly recommend** sending a unique `Idempotency-Key` header 
+    when making those requests to allow for safe retries:
 
 
     * [Request Payment](/#request-payment)
@@ -2764,7 +2768,7 @@ paths:
           <li>["new_payments_platform", "direct_entry"] - enables automatic channel switching if a payment fails on the NPP</li>
         </ul>
 
-        <aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPayment
       requestBody:
         description: ''
@@ -2896,7 +2900,7 @@ paths:
         - Payment Requests
       summary: Request Payment
       description: >
-        <aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPaymentRequest
       parameters: []
       requestBody:
@@ -3033,7 +3037,7 @@ paths:
           <li>The total refunded amount must not exceed the original value</li>
         </ul>
 
-        <aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: IssueARefund
       parameters:
         - name: credit_ref

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -579,6 +579,16 @@ info:
     specified in the `Retry-After` response header.
 
 
+    Currently the following `POST` requests can be made idempotent:
+
+
+    * [Request Payment](/#request-payment)
+
+    * [Make a Payment](/#make-a-payment)
+
+    * [Issue a Refund](/#issue-a-refund)
+
+
     ## Error responses
 
 
@@ -2754,6 +2764,7 @@ paths:
           <li>["new_payments_platform", "direct_entry"] - enables automatic channel switching if a payment fails on the NPP</li>
         </ul>
 
+        <aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPayment
       requestBody:
         description: ''
@@ -2884,7 +2895,8 @@ paths:
       tags:
         - Payment Requests
       summary: Request Payment
-      description: ''
+      description: >
+        <aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPaymentRequest
       parameters: []
       requestBody:
@@ -3020,6 +3032,8 @@ paths:
           <li>Many refunds may be created against the original Payment Request</li>
           <li>The total refunded amount must not exceed the original value</li>
         </ul>
+
+        <aside class="notice">To safely retry this action without accidentally performing the same operation twice, you can supply an <code>Idempotency-Key</code> header. If a header value is different to one provided previously or is omitted, we will be treating a request as a new operation to be performed. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: IssueARefund
       parameters:
         - name: credit_ref


### PR DESCRIPTION
- [Trello card](https://trello.com/c/ZXjeZG0u/95-extend-documentation-to-provide-information-on-how-to-make-idempotent-requests-when-looking-at-specific-api-docs)

When looking at idempotency key details and the api docs, we have noticed that the docs do not state explicitly which requests support idemponecy feature and we do not link from those requests back to the idempotent requests guide. 

As a result, we have decided to extend the docs to make sure it is explicit which API requests support `Idempotency-Key` header to ensure safe re-tries.


## What is in this PR?

- extend te section to outline the negative scenario: 
![image](https://user-images.githubusercontent.com/102490628/175178610-2a744df4-8d51-4ade-827d-d16573d82295.png)
- include the following section as part of the "Idempotent requests" guide:
![image](https://user-images.githubusercontent.com/102490628/174936141-4a2c493b-72b6-4847-83b6-4ace004b99d8.png)
- include the following info box calling out to add idempotency header \ in "Make a payment", "Request Payment" and "Issue a Refund" request docs:
![image](https://user-images.githubusercontent.com/102490628/174936198-44256e0c-58b8-4bdd-a531-38b15a4451f1.png)
![image](https://user-images.githubusercontent.com/102490628/174936244-850884b6-f21a-42a4-8577-8dc95b522626.png)
![image](https://user-images.githubusercontent.com/102490628/174936285-7f2fb60b-4bbb-453d-adf5-86a7c030c6ee.png)
- extend params for each relevant requests to include non-required Idempotency-key header which propagates to examples: 
![image](https://user-images.githubusercontent.com/102490628/175178717-6a8e3567-db7a-45c3-9506-a8a1c1dea1e9.png)
![image](https://user-images.githubusercontent.com/102490628/175178738-1443e4a4-c7ab-4da9-8369-d83b5590dd69.png)
![image](https://user-images.githubusercontent.com/102490628/175178784-61525ee3-099e-4b91-8d29-57975dc2ff62.png)

