### PR TITLE
Document new DE credits blocked failure type

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -8025,6 +8025,7 @@ The rejected, returned, voided & prefailed statuses are always accompanied by a 
 | E151 | Voided By Initiator | The transaction was voided by its initiator. |
 | E152 | Insufficient Funds | There were insufficient funds to complete the transaction. |
 | E153 | System Error | The transaction was unable to complete. Please contact Zepto for assistance. |
+| E154 | Account Blocked | The target account is blocked and cannot receive funds. |
 | E199 | Unknown DE Error | An unknown DE error occurred. Please contact Zepto for assistance. |
 ### DE debit failures
 | Code | Title | Detail |

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1957,6 +1957,8 @@ tags:
 
       | E153 | System Error | The transaction was unable to complete. Please contact Zepto for assistance. |
 
+      | E154 | Account Blocked | The target account is blocked and cannot receive funds. |
+
       | E199 | Unknown DE Error | An unknown DE error occurred. Please contact Zepto for assistance. |
 
       ### DE debit failures


### PR DESCRIPTION
### Context
- No card
- Related: https://github.com/zeptofs/split/pull/8814

[Recently](https://github.com/zeptofs/split/pull/8810) generic failure type was used to handle "DE credits blocked". 

### Change

Document new `E154` failure code for "DE credits blocked". 

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/9605/175123114-a12ba87c-4f00-4ba4-9f7d-dbe6756e9a40.png">
