### PR TITLE
Updated docs following changes to allow merchants to filter webhooks …

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -10260,8 +10260,8 @@ NOTE: Webhook deliveries are stored for 30 days.
 |starting_after|query|string(uuid)|false|Display all webhook deliveries after this webhook delivery offset UUID, single value, exact match|
 |event_type|query|string|false|See ([Data schemas](/#data-schemas)) for a list of possible values, single value, exact match|
 |since|query|string(date-time)|false|Display all webhook deliveries after this date. Date/time UTC ISO 8601 format, single value, exact match|
-|response_status_code|query|string|false|Single value, exact match|
-|state|query|string|false|Filter deliveries by state, single value, exact match. See [Our delivery promise](#our-delivery-promises)|
+|response_status_code|query|array[string]|false|Single value / multiple values separated by commas|
+|state|query|array[string]|false|Filter deliveries by state, single value / multiple values separated by commas. See [Our delivery promise](#our-delivery-promises)|
 
 #### Enumerated Values
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -3633,21 +3633,25 @@ paths:
           example: '2017-05-10T00:00:00Z'
         - name: response_status_code
           in: query
-          description: 'Single value, exact match'
+          description: 'Single value / multiple values separated by commas'
           required: false
           style: simple
           schema:
-            type: string
-            enum: [2xx, 4xx, 5xx]
+            type: array
+            items:
+              type: string
+              enum: [2xx, 4xx, 5xx]
           example: '418'
         - name: state
           in: query
-          description: 'Filter deliveries by state, single value, exact match. See [Our delivery promise](#our-delivery-promises)'
+          description: 'Filter deliveries by state, single value / multiple values separated by commas. See [Our delivery promise](#our-delivery-promises)'
           required: false
           style: simple
           schema:
-            type: string
-            enum: [pending, completed, retrying, failed]
+            type: array
+            items:
+              type: string
+              enum: [pending, completed, retrying, failed]
           example: 'delivered'
       responses:
         '200':


### PR DESCRIPTION
### Context
* Card: [ZEP-2192](https://zeptoau.atlassian.net/browse/ZEP-2192)
* Related: [ZEP-2165](https://github.com/zeptofs/split/pull/8811)


### Change
* Updated docs following Coinbase webhook improvement

**Before**
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/103007917/176817930-2d7788f6-8e28-4a7c-9ee8-368e4320fe81.png">

**After**
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/103007917/176817898-b3860083-5576-44a1-9566-77a6b699477d.png">
