### PR TITLE
Idempotent user scope note

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -396,7 +396,7 @@ Keys expire after 24 hours. If there is a subsequent request with the same idemp
 * Endpoints that use the `GET` or `DELETE` actions are idempotent by nature.
 * A request that quickly follows another with the same idempotency key may return with `503 Service Unavailable`. If so, retry the request after the number of seconds specified in the `Retry-After` response header.
 
-**Caution:** Keys are are scoped to the User making the request. This means if User A makes a request to an Account using idempotency key `123` and an User B makes a request to the same Account using  idempotency key `123` the requests will be treated as different and not idempotent.
+**Caution:** Keys are scoped to the User making the request. This means if User A makes a request to an Account using idempotency key `123` and an User B makes a request to the same Account using  idempotency key `123` the requests will be treated as different and not idempotent.
 
 Currently the following `POST` requests can be made idempotent.  We **strongly recommend** sending a unique `Idempotency-Key` header  when making those requests to allow for safe retries:
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -396,6 +396,8 @@ Keys expire after 24 hours. If there is a subsequent request with the same idemp
 * Endpoints that use the `GET` or `DELETE` actions are idempotent by nature.
 * A request that quickly follows another with the same idempotency key may return with `503 Service Unavailable`. If so, retry the request after the number of seconds specified in the `Retry-After` response header.
 
+**Caution:** Keys are are scoped to the User making the request. This means if User A makes a request to an Account using idempotency key `123` and an User B makes a request to the same Account using  idempotency key `123` the requests will be treated as different and not idempotent.
+
 Currently the following `POST` requests can be made idempotent.  We **strongly recommend** sending a unique `Idempotency-Key` header  when making those requests to allow for safe retries:
 
 * [Request Payment](/#request-payment)

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -581,6 +581,11 @@ info:
     specified in the `Retry-After` response header.
 
 
+    **Caution:** Keys are are scoped to the User making the request. This means if User A makes a request
+    to an Account using idempotency key `123` and an User B makes a request to the same Account using 
+    idempotency key `123` the requests will be treated as different and not idempotent.
+
+
     Currently the following `POST` requests can be made idempotent. 
     We **strongly recommend** sending a unique `Idempotency-Key` header 
     when making those requests to allow for safe retries:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -581,7 +581,7 @@ info:
     specified in the `Retry-After` response header.
 
 
-    **Caution:** Keys are are scoped to the User making the request. This means if User A makes a request
+    **Caution:** Keys are scoped to the User making the request. This means if User A makes a request
     to an Account using idempotency key `123` and an User B makes a request to the same Account using 
     idempotency key `123` the requests will be treated as different and not idempotent.
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Add information on idempotent requests being scoped to users.