### PR TITLE
Remove deprecated Sandbox magic amounts

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -547,8 +547,6 @@ For example:
       <li><a href="#npp-credit-failures">NPP credit failure codes</a></li>
   </ul>
 </aside>
-If you are utilising an [Account Float](https://help.split.cash/en/articles/4275280-utilising-an-account-float) to create NPP payments, you can simulate a transaction that fails to process through the NPP channel by [creating a Payment from your account float](https://help.split.cash/en/articles/4275293-transacting-from-your-account-float).
-
 To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures).
 For example:
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -514,7 +514,7 @@ Failed transactions will contain the following information inside the event:
 * Failure Details
 
 ## DE Transaction failures
-### [NEW] Using failure codes
+### Using failure codes
 <aside class="notice">
   <ul>
       <li><a href="#de-credit-failures">DE credit failure codes</a></li>
@@ -540,59 +540,21 @@ For example:
     * Initiate a Payment Request for <code>$2.03</code>.
     * Zepto will mimic a failure to debit the contact's bank account.
 
-### [DEPRECATED] Using failure reasons
-To simulate [transaction failures](#failure-reasons) create a Payment or Payment Request with a specific amount listed in the table.
-
-| Transaction failure reason | Debit | Credit |
-|----------------------------|-------|--------|
-| `invalid_bsb_number`       |  $0.01  |  $0.51   |
-| `account_closed`           |  $0.02  |  $0.52   |
-| `customer_deceased`        |  $0.03  |  $0.53   |
-| `incorrect_account_number` |  $0.04  |  $0.54   |
-| `refer_to_split`           |  $0.05  |  $0.55   |
-| `user_voided`              |  $0.06  |  $0.56   |
-| `admin_voided`             |  $0.07  |  $0.57   |
-| `refer_to_customer`        |  $0.10  |          |
-| `insufficient_funds`       |  $0.11  |          |
-| `payment_stopped`          |  $0.12  |          |
-
-### [DEPRECATED] Example scenarios
-
-  1. Pay a contact with an invalid account number:
-    * Initiate a Payment for <code>$0.54</code>.
-    * Zepto will mimic a successful debit from your bank account.
-    * Zepto will mimic a failure to credit the contact's bank account.
-    * Zepto will automatically create a <code>payout_reversal</code> credit transaction back to your bank account.
-  2. Pay a contact whilst having insufficient funds:
-    * Initiate a Payment for <code>$0.11</code>.
-    * Zepto will mimic a failure to debit your bank account.
-    * Zepto will mark the debit as `returned` due to `insufficient_funds`.
-    * Zepto will void the scheduled credit to the contact's bank account.
-  3. Request payment from a contact with a closed bank account:
-    * Initiate a Payment Request for <code>$0.02</code>.
-    * Zepto will mimic a failure to debit the contact's bank account.
-
 ## NPP Payment failures
-### [NEW] Using failure codes
+### Using failure codes
 <aside class="notice">
   <ul>
       <li><a href="#npp-credit-failures">NPP credit failure codes</a></li>
   </ul>
 </aside>
+If you are utilising an [Account Float](https://help.split.cash/en/articles/4275280-utilising-an-account-float) to create NPP payments, you can simulate a transaction that fails to process through the NPP channel by [creating a Payment from your account float](https://help.split.cash/en/articles/4275293-transacting-from-your-account-float).
+
 To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures).
 For example:
 
 * NPP amount `$3.02` will cause the transaction to fail, triggering credit failure code `E302` (BSB Not NPP Enabled).
 * NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
 
-### [DEPRECATED] Using failure reasons
-If you are utilising an [Account Float](https://help.split.cash/en/articles/4275280-utilising-an-account-float) to create NPP payments, you can simulate a transaction that fails to process through the NPP channel by [creating a Payment from your account float](https://help.split.cash/en/articles/4275293-transacting-from-your-account-float) for one of the following amounts.
-
-| Transaction failure reason | Failure details | Amount |
-|----------------------------|-----------------|---------|
-| `refer_to_split`           | Real-time payment service currently unavailable |  $1.55  |
-| `refer_to_customer`        | Real-time payment rejected by recipient |  $1.60  |
-| `refer_to_customer`        | Real-time payments not available for recipient |  $1.65  |
 You will receive all the same notifications as if this happened in our live environment. We recommend you check out our article on [what happens when an NPP Payment fails](https://help.split.cash/en/articles/4405560-what-happens-when-an-npp-payment-fails) to learn more about what happens when an NPP Payment is unable to process.
 
 ## Instant account verification accounts

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -797,7 +797,7 @@ info:
 
     ## DE Transaction failures
 
-    ### [NEW] Using failure codes
+    ### Using failure codes
 
     <aside class="notice">
       <ul>
@@ -830,61 +830,21 @@ info:
         * Initiate a Payment Request for <code>$2.03</code>.
         * Zepto will mimic a failure to debit the contact's bank account.
 
-    ### [DEPRECATED] Using failure reasons
-
-    To simulate [transaction failures](#failure-reasons) create a Payment or Payment Request with a specific amount listed in the table.
-
-
-    | Transaction failure reason | Debit | Credit |
-
-    |----------------------------|-------|--------|
-
-    | `invalid_bsb_number`       |  $0.01  |  $0.51   |
-
-    | `account_closed`           |  $0.02  |  $0.52   |
-
-    | `customer_deceased`        |  $0.03  |  $0.53   |
-
-    | `incorrect_account_number` |  $0.04  |  $0.54   |
-
-    | `refer_to_split`           |  $0.05  |  $0.55   |
-
-    | `user_voided`              |  $0.06  |  $0.56   |
-
-    | `admin_voided`             |  $0.07  |  $0.57   |
-
-    | `refer_to_customer`        |  $0.10  |          |
-
-    | `insufficient_funds`       |  $0.11  |          |
-
-    | `payment_stopped`          |  $0.12  |          |
-
-
-    ### [DEPRECATED] Example scenarios
-
-      1. Pay a contact with an invalid account number:
-        * Initiate a Payment for <code>$0.54</code>.
-        * Zepto will mimic a successful debit from your bank account.
-        * Zepto will mimic a failure to credit the contact's bank account.
-        * Zepto will automatically create a <code>payout_reversal</code> credit transaction back to your bank account.
-      2. Pay a contact whilst having insufficient funds:
-        * Initiate a Payment for <code>$0.11</code>.
-        * Zepto will mimic a failure to debit your bank account.
-        * Zepto will mark the debit as `returned` due to `insufficient_funds`.
-        * Zepto will void the scheduled credit to the contact's bank account.
-      3. Request payment from a contact with a closed bank account:
-        * Initiate a Payment Request for <code>$0.02</code>.
-        * Zepto will mimic a failure to debit the contact's bank account.
 
     ## NPP Payment failures
 
-    ### [NEW] Using failure codes
+    ### Using failure codes
 
     <aside class="notice">
       <ul>
           <li><a href="#npp-credit-failures">NPP credit failure codes</a></li>
       </ul>
     </aside>
+
+    If you are utilising an [Account Float](https://help.split.cash/en/articles/4275280-utilising-an-account-float)
+    to create NPP payments, you can simulate a transaction that fails to process through the NPP channel by
+    [creating a Payment from your account float](https://help.split.cash/en/articles/4275293-transacting-from-your-account-float).
+
 
     To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures).
 
@@ -895,24 +855,6 @@ info:
 
     * NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
 
-
-    ### [DEPRECATED] Using failure reasons
-
-    If you are utilising an [Account Float](https://help.split.cash/en/articles/4275280-utilising-an-account-float)
-    to create NPP payments, you can simulate a transaction that fails to process through the NPP channel by
-    [creating a Payment from your account float](https://help.split.cash/en/articles/4275293-transacting-from-your-account-float)
-    for one of the following amounts.
-
-
-    | Transaction failure reason | Failure details | Amount |
-
-    |----------------------------|-----------------|---------|
-
-    | `refer_to_split`           | Real-time payment service currently unavailable |  $1.55  |
-
-    | `refer_to_customer`        | Real-time payment rejected by recipient |  $1.60  |
-
-    | `refer_to_customer`        | Real-time payments not available for recipient |  $1.65  |
 
     You will receive all the same notifications as if this happened in our live environment. We recommend you
     check out our article on [what happens when an NPP Payment fails](https://help.split.cash/en/articles/4405560-what-happens-when-an-npp-payment-fails)

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -841,11 +841,6 @@ info:
       </ul>
     </aside>
 
-    If you are utilising an [Account Float](https://help.split.cash/en/articles/4275280-utilising-an-account-float)
-    to create NPP payments, you can simulate a transaction that fails to process through the NPP channel by
-    [creating a Payment from your account float](https://help.split.cash/en/articles/4275293-transacting-from-your-account-float).
-
-
     To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures).
 
     For example:


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

We are currently using new method to simulate the transaction failure in Sandbox. This PR is to remove the deprecated amounts for DE transaction and NPP Payment failures and this is the [PR reference](https://github.com/zeptofs/split/pull/9442) to remove the deprecated code.

<!-- If PR can't be merged now, what's the condition that allows the merge? -->
## 🚨 Merge criteria
- [x] Remove deprecated Sandbox failure reason [#9442](https://github.com/zeptofs/split/pull/9442) needs to be merged first. After confirmation from Vishakha.