### PR TITLE
Add missing webhooks scope

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -584,6 +584,7 @@ Scopes define the level of access granted via the OAuth2 authorisation process. 
 | `refunds` | Manage user's Refunds |
 | `transfers` | Manage user's Transfers |
 | `transactions` | Access user's Transactions |
+| `webhooks` | Manage user's Webhook events |
 | `offline_access` | Create non-expiring access tokens for user |
 
   <aside class="notice">Please use `offline_access` with discretion, as you'll have no direct way to invalidate the token. Please contact Zepto immediately if any token may have potentially been compromised.</aside>

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -925,6 +925,8 @@ info:
 
     | `transactions` | Access user's Transactions |
 
+    | `webhooks` | Manage user's Webhook events |
+
     | `offline_access` | Create non-expiring access tokens for user |
 
       <aside class="notice">Please use `offline_access` with discretion, as you'll have no direct way to invalidate the token. Please contact Zepto immediately if any token may have potentially been compromised.</aside>


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

While creating an Oauth2 application, we have an option to add `webhooks` as scope. This has been missing in the docs.
This PR adds 'webhook' scope and description.