### PR TITLE
Document category purpose code support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ DEPENDENCIES
   webrick
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 3.0.3p157
 
 BUNDLED WITH
-   2.2.18
+   2.3.9

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -6229,8 +6229,16 @@ To enable custom payment flows, the required payment channel can be selected by 
 |»»» amount|body|integer|true|Amount in cents to pay the recipient|
 |»»» description|body|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
 |»»» recipient_contact_id|body|string|true|Contact to pay (`Contact.data.id`)|
+|»»» category_purpose_code|body|string|false|ISO 20022 code for payment category purpose (see supported values below).|
+|»»» end_to_end_id|body|string|false|End-To-End ID (35 max. characters). Required if a category purpose code is present. For superannuation payments, set this to the Payment Reference Number (PRN).|
 |»»» metadata|body|Metadata|false|Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.|
 |»» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Zepto customisations.|
+
+#### Enumerated Values
+
+|Parameter|Value|
+|---|---|
+|»»» category_purpose_code|PENS|
 
 > Example responses
 
@@ -6256,6 +6264,8 @@ To enable custom payment flows, the required payment channel can be selected by 
         "description": "A tandem skydive jump SB23094",
         "from_id": "83623359-e86e-440c-9780-432a3bc3626f",
         "to_id": "21066764-c103-4e7f-b436-4cee7db5f400",
+        "category_purpose_code": "PENS",
+        "end_to_end_id": "FFC6D34847134E4D8BF4B9B41BDC94C8",
         "metadata": {
           "invoice_ref": "BILL-0001",
           "invoice_id": "c80a9958-e805-47c0-ac2a-c947d7fd778d",
@@ -11954,6 +11964,8 @@ Use this endpoint to resend a failed webhook delivery.
   "amount": 30000,
   "description": "A tandem skydive jump SB23094",
   "recipient_contact_id": "48b89364-1577-4c81-ba02-96705895d457",
+  "category_purpose_code": "PENS",
+  "end_to_end_id": "FFC6D34847134E4D8BF4B9B41BDC94C8",
   "metadata": null
 }
 ```
@@ -11967,7 +11979,15 @@ Use this endpoint to resend a failed webhook delivery.
 |amount|integer|true|Amount in cents to pay the recipient|
 |description|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
 |recipient_contact_id|string|true|Contact to pay (`Contact.data.id`)|
+|category_purpose_code|string|false|ISO 20022 code for payment category purpose (see supported values below).|
+|end_to_end_id|string|false|End-To-End ID (35 max. characters). Required if a category purpose code is present. For superannuation payments, set this to the Payment Reference Number (PRN).|
 |metadata|Metadata|false|Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|category_purpose_code|PENS|
 
 ## VoidAPayoutRequest
 
@@ -12028,6 +12048,8 @@ Use this endpoint to resend a failed webhook delivery.
         "description": "A tandem skydive jump SB23094",
         "from_id": "83623359-e86e-440c-9780-432a3bc3626f",
         "to_id": "21066764-c103-4e7f-b436-4cee7db5f400",
+        "category_purpose_code": "PENS",
+        "end_to_end_id": "FFC6D34847134E4D8BF4B9B41BDC94C8",
         "metadata": {
           "invoice_ref": "BILL-0001",
           "invoice_id": "c80a9958-e805-47c0-ac2a-c947d7fd778d",

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5129,7 +5129,7 @@ func main() {
 
 `POST /payment_requests`
 
-<aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 
@@ -6182,7 +6182,7 @@ To enable custom payment flows, the required payment channel can be selected by 
   <li>["direct_entry"] - for slower traditional payments</li>
   <li>["new_payments_platform", "direct_entry"] - enables automatic channel switching if a payment fails on the NPP</li>
 </ul>
-<aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 
@@ -7230,7 +7230,7 @@ Certain rules apply to the issuance of a refund:
   <li>Many refunds may be created against the original Payment Request</li>
   <li>The total refunded amount must not exceed the original value</li>
 </ul>
-<aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -6230,7 +6230,7 @@ To enable custom payment flows, the required payment channel can be selected by 
 |»»» description|body|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
 |»»» recipient_contact_id|body|string|true|Contact to pay (`Contact.data.id`)|
 |»»» category_purpose_code|body|string|false|ISO 20022 code for payment category purpose (see supported values below).|
-|»»» end_to_end_id|body|string|false|End-To-End ID (35 max. characters). Required when a category purpose code is present. For superannuation or tax payments, set this to the Payment Reference Number (PRN).|
+|»»» end_to_end_id|body|string|false|End-To-End ID (35 max. characters). Required when a category purpose code is present. For superannuation or tax payments, set this to the Payment Reference Number (PRN). For salary payments, set this to the Employee Reference.|
 |»»» metadata|body|Metadata|false|Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.|
 |»» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Zepto customisations.|
 
@@ -6239,6 +6239,7 @@ To enable custom payment flows, the required payment channel can be selected by 
 |Parameter|Value|
 |---|---|
 |»»» category_purpose_code|PENS|
+|»»» category_purpose_code|SALA|
 |»»» category_purpose_code|TAXS|
 
 > Example responses
@@ -11981,7 +11982,7 @@ Use this endpoint to resend a failed webhook delivery.
 |description|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
 |recipient_contact_id|string|true|Contact to pay (`Contact.data.id`)|
 |category_purpose_code|string|false|ISO 20022 code for payment category purpose (see supported values below).|
-|end_to_end_id|string|false|End-To-End ID (35 max. characters). Required when a category purpose code is present. For superannuation or tax payments, set this to the Payment Reference Number (PRN).|
+|end_to_end_id|string|false|End-To-End ID (35 max. characters). Required when a category purpose code is present. For superannuation or tax payments, set this to the Payment Reference Number (PRN). For salary payments, set this to the Employee Reference.|
 |metadata|Metadata|false|Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.|
 
 #### Enumerated Values
@@ -11989,6 +11990,7 @@ Use this endpoint to resend a failed webhook delivery.
 |Property|Value|
 |---|---|
 |category_purpose_code|PENS|
+|category_purpose_code|SALA|
 |category_purpose_code|TAXS|
 
 ## VoidAPayoutRequest

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -6239,6 +6239,7 @@ To enable custom payment flows, the required payment channel can be selected by 
 |Parameter|Value|
 |---|---|
 |»»» category_purpose_code|PENS|
+|»»» category_purpose_code|TAXS|
 
 > Example responses
 
@@ -11988,6 +11989,7 @@ Use this endpoint to resend a failed webhook delivery.
 |Property|Value|
 |---|---|
 |category_purpose_code|PENS|
+|category_purpose_code|TAXS|
 
 ## VoidAPayoutRequest
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -6230,7 +6230,7 @@ To enable custom payment flows, the required payment channel can be selected by 
 |»»» description|body|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
 |»»» recipient_contact_id|body|string|true|Contact to pay (`Contact.data.id`)|
 |»»» category_purpose_code|body|string|false|ISO 20022 code for payment category purpose (see supported values below).|
-|»»» end_to_end_id|body|string|false|End-To-End ID (35 max. characters). Required if a category purpose code is present. For superannuation payments, set this to the Payment Reference Number (PRN).|
+|»»» end_to_end_id|body|string|false|End-To-End ID (35 max. characters). Required when a category purpose code is present. For superannuation or tax payments, set this to the Payment Reference Number (PRN).|
 |»»» metadata|body|Metadata|false|Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.|
 |»» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Zepto customisations.|
 
@@ -11981,7 +11981,7 @@ Use this endpoint to resend a failed webhook delivery.
 |description|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
 |recipient_contact_id|string|true|Contact to pay (`Contact.data.id`)|
 |category_purpose_code|string|false|ISO 20022 code for payment category purpose (see supported values below).|
-|end_to_end_id|string|false|End-To-End ID (35 max. characters). Required if a category purpose code is present. For superannuation payments, set this to the Payment Reference Number (PRN).|
+|end_to_end_id|string|false|End-To-End ID (35 max. characters). Required when a category purpose code is present. For superannuation or tax payments, set this to the Payment Reference Number (PRN).|
 |metadata|Metadata|false|Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.|
 
 #### Enumerated Values

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4825,7 +4825,7 @@ components:
         category_purpose_code:
           type: string
           description: "ISO 20022 code for payment category purpose (see supported values below)."
-          enum: ["PENS"]
+          enum: ["PENS", "TAXS"]
           example: "PENS"
         end_to_end_id:
           type: string

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4832,8 +4832,8 @@ components:
           max: 35
           description: >
             End-To-End ID (35 max. characters).
-            Required if a category purpose code is present.
-            For superannuation payments, set this to the Payment Reference Number (PRN).
+            Required when a category purpose code is present.
+            For superannuation or tax payments, set this to the Payment Reference Number (PRN).
           example: "FFC6D34847134E4D8BF4B9B41BDC94C8"
         metadata:
           type: Metadata

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -2720,7 +2720,7 @@ paths:
           <li>["new_payments_platform", "direct_entry"] - enables automatic channel switching if a payment fails on the NPP</li>
         </ul>
 
-        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPayment
       parameters:
         - name: 'Idempotency-Key'
@@ -2865,7 +2865,7 @@ paths:
         - Payment Requests
       summary: Request Payment
       description: >
-        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPaymentRequest
       parameters:
         - name: 'Idempotency-Key'
@@ -3019,7 +3019,7 @@ paths:
           <li>The total refunded amount must not exceed the original value</li>
         </ul>
 
-        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: IssueARefund
       parameters:
         - name: 'Idempotency-Key'

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4825,7 +4825,7 @@ components:
         category_purpose_code:
           type: string
           description: "ISO 20022 code for payment category purpose (see supported values below)."
-          enum: ["PENS", "TAXS"]
+          enum: ["PENS", "SALA", "TAXS"]
           example: "PENS"
         end_to_end_id:
           type: string
@@ -4834,6 +4834,7 @@ components:
             End-To-End ID (35 max. characters).
             Required when a category purpose code is present.
             For superannuation or tax payments, set this to the Payment Reference Number (PRN).
+            For salary payments, set this to the Employee Reference.
           example: "FFC6D34847134E4D8BF4B9B41BDC94C8"
         metadata:
           type: Metadata

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4822,6 +4822,19 @@ components:
           type: string
           description: Contact to pay (`Contact.data.id`)
           example: 48b89364-1577-4c81-ba02-96705895d457
+        category_purpose_code:
+          type: string
+          description: "ISO 20022 code for payment category purpose (see supported values below)."
+          enum: ["PENS"]
+          example: "PENS"
+        end_to_end_id:
+          type: string
+          max: 35
+          description: >
+            End-To-End ID (35 max. characters).
+            Required if a category purpose code is present.
+            For superannuation payments, set this to the Payment Reference Number (PRN).
+          example: "FFC6D34847134E4D8BF4B9B41BDC94C8"
         metadata:
           type: Metadata
           description: Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.
@@ -4865,6 +4878,8 @@ components:
               description: A tandem skydive jump SB23094
               from_id: 83623359-e86e-440c-9780-432a3bc3626f
               to_id: 21066764-c103-4e7f-b436-4cee7db5f400
+              category_purpose_code: "PENS"
+              end_to_end_id: "FFC6D34847134E4D8BF4B9B41BDC94C8"
               metadata:
                 invoice_ref: BILL-0001
                 invoice_id: c80a9958-e805-47c0-ac2a-c947d7fd778d


### PR DESCRIPTION
### Context

Zepto API now supports a subset of ISO 20022 category purpose codes:

- `PENS` (pension, ie SuperStream superannuation payments);
- `SALA` (salary); and
- `TAXS` (taxation).

### Change

Document the additional optional fields to support the above. 

<img width="1792" alt="image" src="https://github.com/zeptofs/api-documentation/assets/9605/99e8c65c-5a33-45ab-a1ae-620f487e3aee">
