### PR TITLE
FW-180: Make enumerated value path clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Get started
 
 1. Clone the repo
 2. `$ bundle install`
+   - Having trouble running this on an m1 due to openssl errors when installing eventmachine?
+   Try using `gem install eventmachine -v '1.2.7' -- --with-openssl-dir=$(brew --prefix openssl)`
 3. `$ yarn install`
 4. `$ bundle exec foreman start`
 5. Browse to http://localhost:4567 to preview the documentation.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -11590,8 +11590,8 @@ Use this endpoint to resend a failed webhook delivery.
 |---|---|
 |type|Zepto account|
 |type|anyone|
-|state|active|
-|state|removed|
+|bank_account.state|active|
+|bank_account.state|removed|
 |iav_provider|split|
 |iav_provider|proviso|
 |iav_provider|basiq|
@@ -11601,10 +11601,10 @@ Use this endpoint to resend a failed webhook delivery.
 |iav_status|removed|
 |iav_status|credentials_invalid|
 |iav_status|null|
-|state|pending|
-|state|active|
-|state|failed|
-|state|deregistered|
+|payid_details.state|pending|
+|payid_details.state|active|
+|payid_details.state|failed|
+|payid_details.state|deregistered|
 
 ## UpdateAReceivableContactRequest
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4523,6 +4523,7 @@ components:
                   description: 'The BSB number (Min: 6 - Max: 6)'
                 state:
                   type: string
+                  enumeratedValueName: bank_account.state
                   description: The bank account state
                   enum:
                     - active
@@ -4599,6 +4600,7 @@ components:
                   description: Your merchant's alias_name
                 state:
                   type: string
+                  enumeratedValueName: payid_details.state
                   description: Pending -> Active or Failed -> Deregistered (Contact removed)
                   enum:
                     - pending

--- a/widdershins_templates/main.dot
+++ b/widdershins_templates/main.dot
@@ -53,7 +53,7 @@
      for (var p of block.rows) {
        if (p.schema && p.schema.enum) {
          for (var e of p.schema.enum) {
-           enums.push({name:p.name,value:e});
+           enums.push({name:p.name,value:e,enumeratedValueName:p.schema.enumeratedValueName});
          }
        }
      }
@@ -78,7 +78,7 @@
 
 |Property|Value|
 |---|---|
-{{~ enums :e}}|{{=e.name}}|{{=e.value}}|
+{{~ enums :e}}|{{=e.enumeratedValueName||e.name}}|{{=e.value}}|
 {{~}}
 
 {{?}}


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

When viewing enumerated values of a schema, if that schema has more than one property with an enum of the same they appear to be duplicated. It's actually showing two different enums but the name is the ssame.

This PR gives us the option to set an `enumeratedValueName` to make sure we are clear about the path of these enums and will improve users experience when reading the docs.

## Before
![Screenshot 2024-02-22 at 12 53 22 pm](https://github.com/zeptofs/api-documentation/assets/46544374/63959e00-169d-4f37-bb95-b7be070e2322)

## After

Note the change to the `state` enum names

![Screenshot 2024-02-22 at 12 51 13 pm](https://github.com/zeptofs/api-documentation/assets/46544374/068ca7db-6fe7-4ebe-88ae-ebb1d83bfcc5)

