### PR TITLE
chore: add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Prints available commands
+	@# Use `##` to denote command descriptions (eg previous line)
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36mmake %-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: start
+start: ## Starts the application locally
+	bundle install
+	yarn install
+	open http://localhost:4567
+	bundle exec foreman start
+
+.PHONY: publish
+publish: ## Publishes changes directly to Github Pages
+	./deploy.sh

--- a/README.md
+++ b/README.md
@@ -1,51 +1,44 @@
 <img src="https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_logo_black.png" width="300" alt="Zepto Logo" title="Zepto Logo">
 
-Zepto API Documentation
-===
+# Zepto API Documentation
 
 Welcome to the Zepto API documentation source.
 
-How does it work?
----
+## How does it work?
 
-* The Zepto API is documented using the [OpenAPI 3.0.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md).
-* The new [Swagger editor](http://editor.swagger.io/) was used to get the boilerplate done.
-* The API spec is then converted to [Slate](https://github.com/lord/slate) friendly markdown with [Widdershins](https://github.com/mermade/widdershins).
+- The Zepto API is documented using the [OpenAPI 3.0.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md).
+- The new [Swagger editor](http://editor.swagger.io/) was used to get the boilerplate done.
+- The API spec is then converted to [Slate](https://github.com/lord/slate) friendly markdown with [Widdershins](https://github.com/mermade/widdershins).
 
-Get started
----
+## Get started
 
 1. Clone the repo
 2. `$ bundle install`
    - Having trouble running this on an m1 due to openssl errors when installing eventmachine?
-   Try using `gem install eventmachine -v '1.2.7' -- --with-openssl-dir=$(brew --prefix openssl)`
+     Try using `gem install eventmachine -v '1.2.7' -- --with-openssl-dir=$(brew --prefix openssl)`
 3. `$ yarn install`
 4. `$ bundle exec foreman start`
 5. Browse to http://localhost:4567 to preview the documentation.
 6. Edit the `source/openapi3/split.yaml` or any themes/templates. The preview should update a few seconds after
-you save your changes.
+   you save your changes.
 7. Changes to the YAML file will be built and output to the `source/`
    directory, so don't edit the build output in there.
 8. Update the Changelog section of `source/openapi3/split.yaml`.
 9. Commit both the YAML and the build output changes.
 
-
 Note: Currently only changes to split.yaml will trigger the automatic update.
 
+## Publishing changes
 
-Publishing changes
----
 **Warning:** this script will push changes directly to Github pages. They will be publicly visible. You should only run this after your changes have been reviewed and merged.
 
 `$ ./deploy.sh`
 
-Notes
----
+## Notes
 
-* The Slate template/theme is mildly edited to suit our style.
-* The same goes for Widdershin's conversion templates.
+- The Slate template/theme is mildly edited to suit our style.
+- The same goes for Widdershin's conversion templates.
 
-Thanks
----
+## Thanks
 
 Thanks to the teams at Widdershins, Slate, Swagger and OpenAPI spec.

--- a/README.md
+++ b/README.md
@@ -10,21 +10,20 @@ Welcome to the Zepto API documentation source.
 - The new [Swagger editor](http://editor.swagger.io/) was used to get the boilerplate done.
 - The API spec is then converted to [Slate](https://github.com/lord/slate) friendly markdown with [Widdershins](https://github.com/mermade/widdershins).
 
-## Get started
+## Starting application locally
 
-1. Clone the repo
-2. `$ bundle install`
-   - Having trouble running this on an m1 due to openssl errors when installing eventmachine?
-     Try using `gem install eventmachine -v '1.2.7' -- --with-openssl-dir=$(brew --prefix openssl)`
-3. `$ yarn install`
-4. `$ bundle exec foreman start`
-5. Browse to http://localhost:4567 to preview the documentation.
-6. Edit the `source/openapi3/split.yaml` or any themes/templates. The preview should update a few seconds after
+```sh
+make start # Ctrl+C to stop
+```
+
+## Making changes
+
+1. Edit the `source/openapi3/split.yaml` or any themes/templates. The preview should update a few seconds after
    you save your changes.
-7. Changes to the YAML file will be built and output to the `source/`
+2. Changes to the YAML file will be built and output to the `source/`
    directory, so don't edit the build output in there.
-8. Update the Changelog section of `source/openapi3/split.yaml`.
-9. Commit both the YAML and the build output changes.
+3. Update the Changelog section of `source/openapi3/split.yaml`.
+4. Commit both the YAML and the build output changes.
 
 Note: Currently only changes to split.yaml will trigger the automatic update.
 
@@ -32,7 +31,9 @@ Note: Currently only changes to split.yaml will trigger the automatic update.
 
 **Warning:** this script will push changes directly to Github pages. They will be publicly visible. You should only run this after your changes have been reviewed and merged.
 
-`$ ./deploy.sh`
+```sh
+make publish
+```
 
 ## Notes
 


### PR DESCRIPTION
### Context
- There are a few commands to start the application. 

### Change
- Tidy up README markdown formatting with Prettier. 
- Add a `Makefile` to simplify things. 

```
$ make

make help                           Prints available commands
make start                          Starts the application locally
make publish                        Publishes changes directly to Github Pages
```