### PR TITLE
docs: idempotency key limit

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -365,10 +365,12 @@ Refer to the following article to get started: https://help.zepto.money/en/artic
 ```
 
 The Zepto API supports idempotency for safely retrying requests without accidentally performing the same operation twice.
+
 For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is a network connection error, you can retry the Payment with the same idempotency key to guarantee that only a single Payment is created. In case an idempotency key is not supplied and a Payment is retried, we would treat this as two different payments being made.
 
 To perform an idempotent request, provide an additional `Idempotency-Key: <key>` header to the request.
-You can pass any value as the key but we suggest that you use [V4 UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
+
+You can pass any value (up to 256 characters) as the key but we suggest [V4 UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
 
 Keys expire after 24 hours. If there is a subsequent request with the same idempotency key within the 24 hour period, we will return a `409 Conflict`.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -380,8 +380,6 @@ Keys expire after 24 hours. If there is a subsequent request with the same idemp
 * Endpoints that use the `GET` or `DELETE` actions are idempotent by nature.
 * A request that quickly follows another with the same idempotency key may return with `503 Service Unavailable`. If so, retry the request after the number of seconds specified in the `Retry-After` response header.
 
-**Caution:** Keys are scoped to the User making the request. This means if User A makes a request with an access token they have generated to an Account using idempotency key `123` and User B makes a request with their own access token to the same Account using idempotency key `123` the requests will be treated as different and not idempotent.
-
 Currently the following `POST` requests can be made idempotent. We **strongly recommend** sending a unique `Idempotency-Key` header when making those requests to allow for safe retries:
 
 * [Request Payment](/#request-payment)

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -545,12 +545,6 @@ info:
     specified in the `Retry-After` response header.
 
 
-    **Caution:** Keys are scoped to the User making the request. This means if User A makes a request
-    with an access token they have generated to an Account using idempotency key `123` and User B makes a
-    request with their own access token to the same Account using idempotency key `123` the requests will be
-    treated as different and not idempotent.
-
-
     Currently the following `POST` requests can be made idempotent.
     We **strongly recommend** sending a unique `Idempotency-Key` header
     when making those requests to allow for safe retries:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -510,6 +510,7 @@ info:
     The Zepto API supports idempotency for safely retrying requests without
     accidentally performing the same operation twice.
 
+
     For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is
     a network connection error, you can retry the Payment with the same
     idempotency key to guarantee that only a single Payment is created.
@@ -520,9 +521,9 @@ info:
     To perform an idempotent request, provide an additional `Idempotency-Key:
     <key>` header to the request.
 
-    You can pass any value as the key but we suggest that you use [V4
-    UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random
-    string.
+
+    You can pass any value (up to 256 characters) as the key but we suggest [V4
+    UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
 
 
     Keys expire after 24 hours. If there is a subsequent request with the same


### PR DESCRIPTION
### Context
- Currently idempotency key limit isn't documented. 

### Change
- Document 256-character limit. 
- Remove obsolete warning. 