### PR TITLE
docs: update readme.com source for idempotency key limit

### DIFF
--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -493,7 +493,8 @@ For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is a ne
 
 To perform an idempotent request, provide an additional `Idempotency-Key:<key>` header to the request.
 
-You can pass any value as the key but we suggest that you use [V4 UUIDs](https://www.uuidtools.com/generate v4) or another appropriately random string.
+
+You can pass any value (up to 256 characters) as the key but we suggest [V4 UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
 
 
 Keys expire after 24 hours. If there is a subsequent request with the same idempotency key within the 24 hour period, we will return a `409 Conflict`.
@@ -508,9 +509,6 @@ Keys expire after 24 hours. If there is a subsequent request with the same idemp
 * Endpoints that use the `GET` or `DELETE` actions are idempotent by nature.
 
 * A request that quickly follows another with the same idempotency key may return with `503 Service Unavailable`. If so, retry the request after the number of seconds specified in the `Retry-After` response header.
-
-
-**Caution:** Keys are scoped to the User making the request. This means if User A makes a request with an access token they have generated to an Account using idempotency key `123` and User B makes a request with their own access token to the same Account using idempotency key `123` the requests will be treated as different and not idempotent.
 
 
 Currently the following `POST` requests can be made idempotent. We **strongly recommend** sending a unique `Idempotency-Key` header when making those requests to allow for safe retries:


### PR DESCRIPTION
### Context
- Related: #170 

Guide docs published to readme are sourced from `source/guides`. 

### Change
- Update content in `source/guides`. 