### PR TITLE
style: reformat Zepto API guide

### DIFF
--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -12,7 +12,6 @@ Zepto allows you to make, get and manage payments using nothing but bank account
 It is important to understand that there are 2 main ways Zepto can be used for maximum flexibility:
 
 1. Between Zepto accounts.
-
 2. Between a Zepto account and anyone.
 
 Due to the above, certain endpoints and techniques will differ slightly depending on who you are interacting with. You can find more on this in the [Making payments](doc:zepto-api#making-payments) and [Getting paid](doc:zepto-api#getting-paid) guides.
@@ -22,27 +21,16 @@ And for all kinds of How To's and Recipes, head on over to our [Help Guide](http
 # Conventions
 
 - Authentication is performed using OAuth2. See the [Get started](doc:zepto-api#get-started) and [Authentication & Authorisation](doc:zepto-api#authentication-and-authorisation) guides for more.
-
 - All communication is via `https` and supports **only** `TLSv1.2`.
-
 - Production API: `https://api.zeptopayments.com/`.
-
 - Production UI: `https://go.zeptopayments.com/`.
-
 - Sandbox API: `https://api.sandbox.zeptopayments.com/`.
-
 - Sandbox UI: `https://go.sandbox.zeptopayments.com/`.
-
 - Data is sent and received as JSON.
-
 - Clients should include the `Accepts: application/json` header in their requests.
-
 - Currencies are represented by 3 characters as defined in [ISO 4217](http://www.xe.com/iso4217.php).
-
 - Dates & times are returned in UTC using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy. With requests, when no TZ is supplied, the configured TZ of the authenticated user is used, or `Australia/Sydney` if no TZ is configured.
-
 - Amounts are always in cents with no decimals unless otherwise stated.
-
 - Zepto provides static public IP addresses for all outbound traffic, including webhooks.
   - Sandbox IP: `13.237.142.60`
   - Production IPs: `52.64.11.67` and `13.238.78.114`
@@ -57,19 +45,12 @@ If you would like to check platform status programmatically, please refer to [st
 A breaking change is assumed to be:
 
 - Renaming a parameter (request/response)
-
 - Removing a parameter (request/response)
-
 - Changing a parameter type (request/response)
-
 - Renaming a header (request/response)
-
 - Removing a header (request/response)
-
 - Application of stricter validation rules for request parameters
-
 - Reducing the set of possible enumeration values for a request
-
 - Changing a HTTP response status code
 
 We take backwards compatibility very seriously, and will make every effort to ensure this never changes. In the unfortunate (and rare) case where a breaking change can not be avoided, these will be announced well in
@@ -78,15 +59,10 @@ advance, enabling a transition period for API consumers.
 The following are not assumed to be a breaking change and must be taken into account by API consumers:
 
 - Addition of optional new parameters in request
-
 - Addition of new parameters in response
-
 - Addition of new headers in request
-
 - Reordering of parameters in response
-
 - Softening of validation rules for request parameters
-
 - Increasing the set of possible enumeration values
 
 In the case of non breaking changes, a transition period may not be provided, meaning the possibility of such changes occurring must be considered in consumers' logic so as not to break any integrations with both API and Webhooks.
@@ -105,43 +81,20 @@ Before you start, **import a copy** of our API collection:
 Okay, let's get things setup!
 
 1. **Create a Zepto account**
-
    If you haven't already, you'll want to create a sandbox Zepto account at <https://go.sandbox.zeptopayments.com>
-
 2. **Register your application with Zepto**
-
    Sign in and create an OAuth2 application: <https://go.sandbox.zeptopayments.com/oauth/applications>.
-
    [![Zepto OAuth2 app create](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_create.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_create.png)
-
 3. **Generate personal access tokens**
-
-   ```
    The quickest way to access your Zepto account via the API is using personal access tokens. Click on your newly created application from your [application list](https://go.sandbox.zeptopayments.com/oauth applications) and click on
-   ```
-
-   **+ Personal Access Token**.
-
-   ```
-   [![Zepto locate personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
-
+   [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
    _(You'll have the option to give the token a title)_
-
-   [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)
-
    > **_NOTE:_** Please note that personal access tokens do not expire.
-   ```
-
 4. **Use personal access token in Postman**
-
    You can use this `access_token` to authorise any requests to the Zepto API in Postman by choosing the **Bearer Token** option under the **Authorization** tab.
-
    [![Postman use personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_personal_access_token.png)
-
 5. **Make an API request!**
-
    You are now ready to interact with your Zepto account via the API! Go ahead and send a request using Postman.
-
    [![Postman use personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_request_response.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_request_response.png)
 
 ## Get started
@@ -151,36 +104,25 @@ This guide will help you setup an OAuth2 app in order to get authenticated & aut
 **Before you start:**
 
 - We use the term **user** below but the user can be a third party or the same user that owns the OAuth2 application.
-
 - As noted below, some access tokens expire every 2 hours. To get a new access token use the [refresh grant strategy](doc:zepto-api#authentication-and-authorisation) to swap a refresh token for a new access token.
 
 1. **Create a Zepto account**
-
    If you haven't already, you'll want to create a sandbox Zepto account at <https://go.sandbox.zeptopayments.com>.
-
 2. **Choose authentication method**
-
    All requests to the Zepto API require an `access_token` for authentication. There are two options for obtaining these tokens, the correct option will depend on your use case:
-
-   **Personal access token** If you only need to access your own Zepto account via the API, then using personal access tokens are the most straight-forward way. Refer to [Personal access token](doc:zepto-api#personal-access-token) to setup. These tokens do not expire so no refreshing is required.
-
-   **OAuth grant flow** When you require your application to act on behalf of other Zepto accounts you'll need to implement the OAuth grant flow process. Refer to [OAuth grant flow guide](doc:zepto-api#oauth-grant-flow) to setup. There is also an [OAuth grant flow tutorial](doc:zepto-api#oauth-grant-flow-tutorial). These access tokens expire every 2 hours, unless the `offline_access` scope is used in which case the tokens will not expire.
+   - **Personal access token** If you only need to access your own Zepto account via the API, then using personal access tokens are the most straight-forward way. Refer to [Personal access token](doc:zepto-api#personal-access-token) to setup. These tokens do not expire so no refreshing is required.
+   - **OAuth grant flow** When you require your application to act on behalf of other Zepto accounts you'll need to implement the OAuth grant flow process. Refer to [OAuth grant flow guide](doc:zepto-api#oauth-grant-flow) to setup. There is also an [OAuth grant flow tutorial](doc:zepto-api#oauth-grant-flow-tutorial). These access tokens expire every 2 hours, unless the `offline_access` scope is used in which case the tokens will not expire.
 
 ## Personal access token
 
-If you're looking to only access your own account via the API, you can generate a personal access token from the UI. These tokens do not expire, but can be deleted.
+If you're looking to only access your own account via the API, you can generate a personal access token from the UI. These tokens do not expire, but can be deleted. To do this:
 
-- To do this, sign in to your Zepto account and [create an application](https://go.sandbox.zeptopayments.com/oauth/applications) if you haven't already. Click on your application from your [application list](https://go.sandbox.zeptopayments.com/oauth/applications) and click on **Personal access**.
-
-  [![Zepto locate personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
-
-  _(You'll have the option to give the token a title)_
-
-  [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)
-
-- Now that you have an `access_token` you can interact with your Zepto account via the API.
-
-  To do so, you must simply append the access token to the header of any API request: `Authorization: Bearer {access_token}`
+1. Sign in to your Zepto account and [create an application](https://go.sandbox.zeptopayments.com/oauth/applications) if you haven't already. Click on your application from your [application list](https://go.sandbox.zeptopayments.com/oauth/applications) and click on **Personal access**.
+   [![Zepto locate personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
+   _(You'll have the option to give the token a title)_
+   [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)
+2. Now that you have an `access_token` you can interact with your Zepto account via the API.
+   To do so, you must simply append the access token to the header of any API request: `Authorization: Bearer {access_token}`
 
 ## OAuth grant flow
 
@@ -349,7 +291,7 @@ When using the authorisation code grant above, Zepto will return a `refresh toke
 When the access token expires, instead of sending the user back through the authorisation flow you can use the refresh token to retrieve a new access token with the same permissions as the old one.
 
 > **_NOTE:_**
->  The `refresh_token` gets regenerated and sent alongside the new `access_token`. In other words, `refresh_token`s are single use so you'll want to store the newly generated `refresh_token` everytime you use it to get a new `access_token`
+> The `refresh_token` gets regenerated and sent alongside the new `access_token`. In other words, `refresh_token`s are single use so you'll want to store the newly generated `refresh_token` everytime you use it to get a new `access_token`
 
 ## Making payments
 

--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -172,15 +172,15 @@ If you're looking to only access your own account via the API, you can generate 
 
 - To do this, sign in to your Zepto account and [create an application](https://go.sandbox.zeptopayments.com/oauth/applications) if you haven't already. Click on your application from your [application list](https://go.sandbox.zeptopayments.com/oauth/applications) and click on **Personal access**.
 
-    [![Zepto locate personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
+  [![Zepto locate personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
 
-    _(You'll have the option to give the token a title)_
+  _(You'll have the option to give the token a title)_
 
-    [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)
+  [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)
 
 - Now that you have an `access_token` you can interact with your Zepto account via the API.
 
-    To do so, you must simply append the access token to the header of any API request: `Authorization: Bearer {access_token}`
+  To do so, you must simply append the access token to the header of any API request: `Authorization: Bearer {access_token}`
 
 ## OAuth grant flow
 
@@ -335,15 +335,13 @@ curl -F "grant_type=refresh_token" \
 > Example response
 
 ```json
-
 {
-    "access_token": "ad0b5847cb7d254f1e2ff1910275fe9dcb95345c9d54502d156fe35a37b93e80",
-    "token_type": "bearer",
-    "expires_in": 7200,
-    "refresh_token": "cc38f78a5b8abe8ee81cdf25b1ca74c3fa10c3da2309de5ac37fde00cbcf2815",
-    "scope": "public"
+  "access_token": "ad0b5847cb7d254f1e2ff1910275fe9dcb95345c9d54502d156fe35a37b93e80",
+  "token_type": "bearer",
+  "expires_in": 7200,
+  "refresh_token": "cc38f78a5b8abe8ee81cdf25b1ca74c3fa10c3da2309de5ac37fde00cbcf2815",
+  "scope": "public"
 }
-
 ```
 
 When using the authorisation code grant above, Zepto will return a `refresh token` along with the access token. Access tokens are short lived and last 2 hours but refresh tokens do not expire.
@@ -351,7 +349,7 @@ When using the authorisation code grant above, Zepto will return a `refresh toke
 When the access token expires, instead of sending the user back through the authorisation flow you can use the refresh token to retrieve a new access token with the same permissions as the old one.
 
 > **_NOTE:_**  
->   The `refresh_token` gets regenerated and sent alongside the new `access_token`. In other words, `refresh_token`s are single use so you'll want to store the newly generated `refresh_token` everytime you use it to get a new `access_token`
+>  The `refresh_token` gets regenerated and sent alongside the new `access_token`. In other words, `refresh_token`s are single use so you'll want to store the newly generated `refresh_token` everytime you use it to get a new `access_token`
 
 ## Making payments
 
@@ -402,7 +400,6 @@ Example flow embedding an [Open Agreement link](https://help.zepto.money/agreeme
 > Example response
 
 ```json
-
 {
   "errors": [
     {
@@ -417,7 +414,6 @@ Example flow embedding an [Open Agreement link](https://help.zepto.money/agreeme
     }
   ]
 }
-
 ```
 
 The Zepto API supports idempotency for safely retrying requests without accidentally performing the same operation twice.
@@ -453,7 +449,6 @@ Currently the following `POST` requests can be made idempotent. We **strongly re
 > Example detailed error response
 
 ```json
-
 {
   "errors": [
     {
@@ -465,17 +460,14 @@ Currently the following `POST` requests can be made idempotent. We **strongly re
     }
   ]
 }
-
 ```
 
 > Example resource error response
 
 ```json
-
 {
   "errors": "A sentence explaining error/s encounted"
 }
-
 ```
 
 The Zepto API returns two different types of error responses depending on the context.
@@ -561,15 +553,13 @@ You can also pass the values directly to the sign up page outside of the OAuth2 
 > Example failure object
 
 ```json
-
 {
   "failure": {
-      "code": "E302",
-      "title": "BSB Not NPP Enabled",
-      "detail": "The target BSB is not NPP enabled. Please try another channel."
+    "code": "E302",
+    "title": "BSB Not NPP Enabled",
+    "detail": "The target BSB is not NPP enabled. Please try another channel."
   }
 }
-
 ```
 
 Try out your happy paths and not-so happy paths; the sandbox is a great place to get started without transferring actual funds. All transactions are simulated and no communication with financial institutions is performed.
@@ -690,25 +680,23 @@ You can control the pagination by including `per_page=x` and/or `page=x` in the 
 
 The `Link` header will be optionally present if a "next page" is available to navigate to. The next page link is identified with `rel="next"`
 
->  **Legacy Pagination**: Some existing users may still be on a transitional legacy version of pagination.
+> **Legacy Pagination**: Some existing users may still be on a transitional legacy version of pagination.
 >
->  The Legacy version returns some extra **deprecated header values: `Total` plus `rel="last"` & `rel="prev"` in `Link`**.
+> The Legacy version returns some extra **deprecated header values: `Total` plus `rel="last"` & `rel="prev"` in `Link`**.
 >
->  Please transition to only using the `rel="next"` from the `Link` header, as all other values are deprecated.
+> Please transition to only using the `rel="next"` from the `Link` header, as all other values are deprecated.
 
 ## Remitter
 
 > Example request
 
 ```json
-
 {
   "...": "...",
   "metadata": {
     "remitter": "CustomRem"
-    }
+  }
 }
-
 ```
 
 You can elect to assign a remitter name on a per-request basis when submitting Payments & Payment Requests. Simply append the `remitter` key and a value within the `metadata` key.
@@ -744,7 +732,6 @@ Should you prefer debit aggregation to be disabled, please contact [support@zept
 > Example response
 
 ```json
-
 {
   "event": {
     "type": "object.action",
@@ -754,11 +741,8 @@ Should you prefer debit aggregation to be disabled, please contact [support@zept
       "bank_account_id": "x"
     }
   },
-  "data": [
-    {}
-  ]
+  "data": [{}]
 }
-
 ```
 
 Please refer to our help centre [article on webhooks](http://help.zepto.money/en/articles/3303626-webhooks) for more information and an overview of what you can achieve with webhooks.
@@ -950,40 +934,35 @@ puts(given_signature)
 ```
 
 ```javascript
+var crypto = require("crypto");
 
-var crypto = require('crypto')
+var message = "full payload of the request";
 
-var message = 'full payload of the request'
-
-var secret = '1234'
+var secret = "1234";
 
 var splitSignature =
-'1514772000.f04cb05adb985b29d84616fbf3868e8e58403ff819cdc47ad8fc47e6acbce29f'
+  "1514772000.f04cb05adb985b29d84616fbf3868e8e58403ff819cdc47ad8fc47e6acbce29f";
 
+var data = splitSignature.split(".");
 
-var data = splitSignature.split('.')
+var timestamp = data[0];
 
-var timestamp = data[0]
+var givenSignature = data[1];
 
-var givenSignature = data[1]
+var signedPayload = timestamp + "." + message;
 
+var expectedSignature = crypto
+  .createHmac("sha256", secret)
+  .update(signedPayload)
+  .digest("hex");
 
-var signedPayload = timestamp + '.' + message
-
-
-var expectedSignature = crypto.createHmac('sha256',
-secret).update(signedPayload).digest('hex')
-
-
-console.log(expectedSignature)
+console.log(expectedSignature);
 
 // f04cb05adb985b29d84616fbf3868e8e58403ff819cdc47ad8fc47e6acbce29f
 
-console.log(givenSignature)
+console.log(givenSignature);
 
 // f04cb05adb985b29d84616fbf3868e8e58403ff819cdc47ad8fc47e6acbce29f
-
-
 ```
 
 ```php
@@ -1058,7 +1037,7 @@ class Main {
 
 <!--
 
- 
+
 
 This example is commented out since the docs do not include C#
 

--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -49,7 +49,7 @@ And for all kinds of How To's and Recipes, head on over to our [Help Guide](http
 
 # System Status
 
-Check the platform status, or subscribe to receive notifications at [status.zeptopayments.com](https://status.zeptopayments.com/).  
+Check the platform status, or subscribe to receive notifications at [status.zeptopayments.com](https://status.zeptopayments.com/).
 If you would like to check platform status programmatically, please refer to [status.zeptopayments.com/api](https://status.zeptopayments.com/api).
 
 # Breaking Changes
@@ -72,7 +72,7 @@ A breaking change is assumed to be:
 
 - Changing a HTTP response status code
 
-We take backwards compatibility very seriously, and will make every effort to ensure this never changes. In the unfortunate (and rare) case where a breaking change can not be avoided, these will be announced well in  
+We take backwards compatibility very seriously, and will make every effort to ensure this never changes. In the unfortunate (and rare) case where a breaking change can not be avoided, these will be announced well in
 advance, enabling a transition period for API consumers.
 
 The following are not assumed to be a breaking change and must be taken into account by API consumers:
@@ -97,7 +97,7 @@ In the case of non breaking changes, a transition period may not be provided, me
 
 The best way to familiarise yourself with our API is by interacting with it.
 
-We've preloaded a collection with all our endpoints for you to use in Postman.  
+We've preloaded a collection with all our endpoints for you to use in Postman.
 Before you start, **import a copy** of our API collection:
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/3168734-baa5ff70-4bc2-44d5-9ba6-fcb61839ff41?action=collection%2Ffork&collection-url=entityId%3D3168734-baa5ff70-4bc2-44d5-9ba6-fcb61839ff41%26entityType%3Dcollection%26workspaceId%3D6400ea2b-bb46-421e-a88c-a8625653c35a#?env%5BSplit%20Payments%20Public%20Sandbox%5D=W3sia2V5Ijoic2l0ZV9ob3N0IiwidmFsdWUiOiJodHRwczovL2dvLnNhbmRib3guc3BsaXQuY2FzaCIsImVuYWJsZWQiOnRydWV9LHsia2V5IjoiYXBpX2hvc3QiLCJ2YWx1ZSI6Imh0dHBzOi8vYXBpLnNhbmRib3guc3BsaXQuY2FzaCIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoib2F1dGgyX2FwcGxpY2F0aW9uX2lkIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6Im9hdXRoMl9zZWNyZXQiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoic2NvcGUiLCJ2YWx1ZSI6InB1YmxpYyBhZ3JlZW1lbnRzIGJhbmtfYWNjb3VudHMgYmFua19jb25uZWN0aW9ucyBjb250YWN0cyBwYXltZW50cyBwYXltZW50X3JlcXVlc3RzIHJlZnVuZF9yZXF1ZXN0cyB0cmFuc2FjdGlvbnMgcmVmdW5kcyBvcGVuX2FncmVlbWVudHMgb2ZmbGluZV9hY2Nlc3MiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6Imlzbzg2MDFfbm93IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFjY2Vzc190b2tlbiIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJyZWZyZXNoX3Rva2VuIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfV0=)
@@ -197,7 +197,7 @@ If you're looking to only access your own account via the API, you can generate 
 
    Construct the initial URL the user will need to visit in order to grant your application permission to act on his/her behalf. The constructed URL describes the level of permission ([`scope`](doc:zepto-api#scopes)), the application requesting permission (`client_id`) and where the user gets redirected once they've granted permission (`redirect_uri`).
 
-   The URL should be formatted to look like this:  
+   The URL should be formatted to look like this:
    `https://go.sandbox.zeptopayments.com/oauth/authorize?response_type=code&client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}`
 
    | Parameter       | Description                                                                                |
@@ -229,7 +229,7 @@ If you're looking to only access your own account via the API, you can generate 
 
 4. **Wrap-up**
 
-   Now that you have an access token and refresh token, you can interact with the Zepto API as the user related to the access token.  
+   Now that you have an access token and refresh token, you can interact with the Zepto API as the user related to the access token.
    To do so, you must simply append the access token to the header of any API request: `Authorization: Bearer {access_token}`
 
 ## OAuth grant flow tutorial
@@ -240,7 +240,7 @@ Before you start, load up our API collection:
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/3168734-baa5ff70-4bc2-44d5-9ba6-fcb61839ff41?action=collection%2Ffork&collection-url=entityId%3D3168734-baa5ff70-4bc2-44d5-9ba6-fcb61839ff41%26entityType%3Dcollection%26workspaceId%3D6400ea2b-bb46-421e-a88c-a8625653c35a#?env%5BSplit%20Payments%20Public%20Sandbox%5D=W3sia2V5Ijoic2l0ZV9ob3N0IiwidmFsdWUiOiJodHRwczovL2dvLnNhbmRib3guc3BsaXQuY2FzaCIsImVuYWJsZWQiOnRydWV9LHsia2V5IjoiYXBpX2hvc3QiLCJ2YWx1ZSI6Imh0dHBzOi8vYXBpLnNhbmRib3guc3BsaXQuY2FzaCIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoib2F1dGgyX2FwcGxpY2F0aW9uX2lkIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6Im9hdXRoMl9zZWNyZXQiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoic2NvcGUiLCJ2YWx1ZSI6InB1YmxpYyBhZ3JlZW1lbnRzIGJhbmtfYWNjb3VudHMgYmFua19jb25uZWN0aW9ucyBjb250YWN0cyBwYXltZW50cyBwYXltZW50X3JlcXVlc3RzIHJlZnVuZF9yZXF1ZXN0cyB0cmFuc2FjdGlvbnMgcmVmdW5kcyBvcGVuX2FncmVlbWVudHMgb2ZmbGluZV9hY2Nlc3MiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6Imlzbzg2MDFfbm93IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFjY2Vzc190b2tlbiIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJyZWZyZXNoX3Rva2VuIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfV0=)
 
-**A screencast of this process is also available:  
+**A screencast of this process is also available:
 <https://vimeo.com/246203244>.**
 
 1. **Create a Zepto account**
@@ -297,7 +297,7 @@ Before you start, load up our API collection:
 
    [![Postman use token](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_token.png)
 
-> **_NOTE:_** Remember to select the access token everytime you try  
+> **_NOTE:_** Remember to select the access token everytime you try
 > a new endpoint. Have fun!
 
 ## Authentication and Authorisation
@@ -348,7 +348,7 @@ When using the authorisation code grant above, Zepto will return a `refresh toke
 
 When the access token expires, instead of sending the user back through the authorisation flow you can use the refresh token to retrieve a new access token with the same permissions as the old one.
 
-> **_NOTE:_**  
+> **_NOTE:_**
 >  The `refresh_token` gets regenerated and sent alongside the new `access_token`. In other words, `refresh_token`s are single use so you'll want to store the newly generated `refresh_token` everytime you use it to get a new `access_token`
 
 ## Making payments
@@ -545,7 +545,7 @@ As an example, the following authorisation URL would display the **personal sign
 
 `https://go.sandbox.zeptopayments.com/oauth/authorize?response_type=code&client_id=xxx&redirect_uri=xxx&scope=xxx&landing=sign_up&first_name=George`
 
-You can also pass the values directly to the sign up page outside of the OAuth2 authorisation process. Click on the following link to see the values preloaded:  
+You can also pass the values directly to the sign up page outside of the OAuth2 authorisation process. Click on the following link to see the values preloaded:
 [https://go.sandbox.zeptopayments.com/business/sign_up?name=GeorgeCo&nickname=georgeco&first_name=George](https://go.sandbox.zeptopayments.com/business/sign_up?name=GeorgeCo&nickname=georgceco&first_name=George).
 
 # Sandbox Testing Details
@@ -627,8 +627,8 @@ You will receive all the same notifications as if this happened in our live envi
 
 ## Instant account verification accounts
 
-When using any of our hosted solutions ([Payment Requests](https://help.zepto.money/en/?q=payment+request),  
-[Open Agreements](https://help.zepto.money/agreements/open-agreement) or  
+When using any of our hosted solutions ([Payment Requests](https://help.zepto.money/en/?q=payment+request),
+[Open Agreements](https://help.zepto.money/agreements/open-agreement) or
 [Unassigned Agreements](http://help.zepto.money/agreements/unassigned-agreement)) you may want to test the [Instant Account Verification (IAV)](http://help.zepto.money/bank-accounts/instant-account-verification-iav) process where we accept online banking credentials to validate bank account access. To do so, you can use the following credentials:
 
 | Login      | Password      |

--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -9,190 +9,168 @@ hidden: false
 
 Zepto allows you to make, get and manage payments using nothing but bank accounts.
 
-
 It is important to understand that there are 2 main ways Zepto can be used for maximum flexibility:
-
 
 1. Between Zepto accounts.
 
 2. Between a Zepto account and anyone.
 
-
 Due to the above, certain endpoints and techniques will differ slightly depending on who you are interacting with. You can find more on this in the [Making payments](doc:zepto-api#making-payments) and [Getting paid](doc:zepto-api#getting-paid) guides.
-
 
 And for all kinds of How To's and Recipes, head on over to our [Help Guide](https://help.zepto.money/en/).
 
 # Conventions
 
+- Authentication is performed using OAuth2. See the [Get started](doc:zepto-api#get-started) and [Authentication & Authorisation](doc:zepto-api#authentication-and-authorisation) guides for more.
 
-* Authentication is performed using OAuth2. See the [Get started](doc:zepto-api#get-started) and [Authentication & Authorisation](doc:zepto-api#authentication-and-authorisation) guides for more.
+- All communication is via `https` and supports **only** `TLSv1.2`.
 
-* All communication is via `https` and supports **only** `TLSv1.2`.
+- Production API: `https://api.zeptopayments.com/`.
 
-* Production API: `https://api.zeptopayments.com/`.
+- Production UI: `https://go.zeptopayments.com/`.
 
-* Production UI: `https://go.zeptopayments.com/`.
+- Sandbox API: `https://api.sandbox.zeptopayments.com/`.
 
-* Sandbox API: `https://api.sandbox.zeptopayments.com/`.
+- Sandbox UI: `https://go.sandbox.zeptopayments.com/`.
 
-* Sandbox UI: `https://go.sandbox.zeptopayments.com/`.
+- Data is sent and received as JSON.
 
-* Data is sent and received as JSON.
+- Clients should include the `Accepts: application/json` header in their requests.
 
-* Clients should include the `Accepts: application/json` header in their requests.
+- Currencies are represented by 3 characters as defined in [ISO 4217](http://www.xe.com/iso4217.php).
 
-* Currencies are represented by 3 characters as defined in [ISO 4217](http://www.xe.com/iso4217.php).
+- Dates & times are returned in UTC using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy. With requests, when no TZ is supplied, the configured TZ of the authenticated user is used, or `Australia/Sydney` if no TZ is configured.
 
-* Dates & times are returned in UTC using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy. With requests, when no TZ is supplied, the configured TZ of the authenticated user is used, or `Australia/Sydney` if no TZ is configured.
+- Amounts are always in cents with no decimals unless otherwise stated.
 
-* Amounts are always in cents with no decimals unless otherwise stated.
-
-* Zepto provides static public IP addresses for all outbound traffic, including webhooks.
-    * Sandbox IP: `13.237.142.60`
-    * Production IPs: `52.64.11.67` and `13.238.78.114`
-
+- Zepto provides static public IP addresses for all outbound traffic, including webhooks.
+  - Sandbox IP: `13.237.142.60`
+  - Production IPs: `52.64.11.67` and `13.238.78.114`
 
 # System Status
 
-
-Check the platform status, or subscribe to receive notifications at [status.zeptopayments.com](https://status.zeptopayments.com/).
+Check the platform status, or subscribe to receive notifications at [status.zeptopayments.com](https://status.zeptopayments.com/).  
 If you would like to check platform status programmatically, please refer to [status.zeptopayments.com/api](https://status.zeptopayments.com/api).
-
 
 # Breaking Changes
 
-
 A breaking change is assumed to be:
 
+- Renaming a parameter (request/response)
 
-* Renaming a parameter (request/response)
+- Removing a parameter (request/response)
 
-* Removing a parameter (request/response)
+- Changing a parameter type (request/response)
 
-* Changing a parameter type (request/response)
+- Renaming a header (request/response)
 
-* Renaming a header (request/response)
+- Removing a header (request/response)
 
-* Removing a header (request/response)
+- Application of stricter validation rules for request parameters
 
-* Application of stricter validation rules for request parameters
+- Reducing the set of possible enumeration values for a request
 
-* Reducing the set of possible enumeration values for a request
+- Changing a HTTP response status code
 
-* Changing a HTTP response status code
-
-
-We take backwards compatibility very seriously, and will make every effort to ensure this never changes. In the unfortunate (and rare) case where a breaking change can not be avoided, these will be announced well in
+We take backwards compatibility very seriously, and will make every effort to ensure this never changes. In the unfortunate (and rare) case where a breaking change can not be avoided, these will be announced well in  
 advance, enabling a transition period for API consumers.
-
 
 The following are not assumed to be a breaking change and must be taken into account by API consumers:
 
+- Addition of optional new parameters in request
 
-* Addition of optional new parameters in request
+- Addition of new parameters in response
 
-* Addition of new parameters in response
+- Addition of new headers in request
 
-* Addition of new headers in request
+- Reordering of parameters in response
 
-* Reordering of parameters in response
+- Softening of validation rules for request parameters
 
-* Softening of validation rules for request parameters
-
-* Increasing the set of possible enumeration values
-
+- Increasing the set of possible enumeration values
 
 In the case of non breaking changes, a transition period may not be provided, meaning the possibility of such changes occurring must be considered in consumers' logic so as not to break any integrations with both API and Webhooks.
 
-
 # Guides
-
 
 ## Try it out
 
 The best way to familiarise yourself with our API is by interacting with it.
 
-
-We've preloaded a collection with all our endpoints for you to use in Postman.
+We've preloaded a collection with all our endpoints for you to use in Postman.  
 Before you start, **import a copy** of our API collection:
-
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/3168734-baa5ff70-4bc2-44d5-9ba6-fcb61839ff41?action=collection%2Ffork&collection-url=entityId%3D3168734-baa5ff70-4bc2-44d5-9ba6-fcb61839ff41%26entityType%3Dcollection%26workspaceId%3D6400ea2b-bb46-421e-a88c-a8625653c35a#?env%5BSplit%20Payments%20Public%20Sandbox%5D=W3sia2V5Ijoic2l0ZV9ob3N0IiwidmFsdWUiOiJodHRwczovL2dvLnNhbmRib3guc3BsaXQuY2FzaCIsImVuYWJsZWQiOnRydWV9LHsia2V5IjoiYXBpX2hvc3QiLCJ2YWx1ZSI6Imh0dHBzOi8vYXBpLnNhbmRib3guc3BsaXQuY2FzaCIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoib2F1dGgyX2FwcGxpY2F0aW9uX2lkIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6Im9hdXRoMl9zZWNyZXQiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoic2NvcGUiLCJ2YWx1ZSI6InB1YmxpYyBhZ3JlZW1lbnRzIGJhbmtfYWNjb3VudHMgYmFua19jb25uZWN0aW9ucyBjb250YWN0cyBwYXltZW50cyBwYXltZW50X3JlcXVlc3RzIHJlZnVuZF9yZXF1ZXN0cyB0cmFuc2FjdGlvbnMgcmVmdW5kcyBvcGVuX2FncmVlbWVudHMgb2ZmbGluZV9hY2Nlc3MiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6Imlzbzg2MDFfbm93IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFjY2Vzc190b2tlbiIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJyZWZyZXNoX3Rva2VuIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfV0=)
 
-
 Okay, let's get things setup!
-
 
 1. **Create a Zepto account**
 
-    If you haven't already, you'll want to create a sandbox Zepto account at [https://go.sandbox.zeptopayments.com](https://go.sandbox.zeptopayments.com)
+   If you haven't already, you'll want to create a sandbox Zepto account at <https://go.sandbox.zeptopayments.com>
 
 2. **Register your application with Zepto**
 
-    Sign in and create an OAuth2 application: [https://go.sandbox.zeptopayments.com/oauth/applications](https://go.sandbox.zeptopayments.com/oauth/applications).
+   Sign in and create an OAuth2 application: <https://go.sandbox.zeptopayments.com/oauth/applications>.
 
-    [![Zepto OAuth2 app create](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_create.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_create.png)
+   [![Zepto OAuth2 app create](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_create.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_create.png)
 
 3. **Generate personal access tokens**
 
-    The quickest way to access your Zepto account via the API is using personal access tokens. Click on your newly created application from your [application list](https://go.sandbox.zeptopayments.com/oauth applications) and click on
-**+ Personal Access Token**.
+   ```
+   The quickest way to access your Zepto account via the API is using personal access tokens. Click on your newly created application from your [application list](https://go.sandbox.zeptopayments.com/oauth applications) and click on
+   ```
 
-    [![Zepto locate personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
+   **+ Personal Access Token**.
 
-    _(You'll have the option to give the token a title)_
+   ```
+   [![Zepto locate personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
 
-    [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)
+   _(You'll have the option to give the token a title)_
 
-    > **_NOTE:_** Please note that personal access tokens do not expire.
+   [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)
+
+   > **_NOTE:_** Please note that personal access tokens do not expire.
+   ```
 
 4. **Use personal access token in Postman**
 
-    You can use this `access_token` to authorise any requests to the Zepto API in Postman by choosing the **Bearer Token** option under the **Authorization** tab.
+   You can use this `access_token` to authorise any requests to the Zepto API in Postman by choosing the **Bearer Token** option under the **Authorization** tab.
 
-    [![Postman use personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_personal_access_token.png)
+   [![Postman use personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_personal_access_token.png)
 
 5. **Make an API request!**
 
-    You are now ready to interact with your Zepto account via the API! Go ahead and send a request using Postman.
+   You are now ready to interact with your Zepto account via the API! Go ahead and send a request using Postman.
 
-    [![Postman use personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_request_response.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_request_response.png)
-
-
+   [![Postman use personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_request_response.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_request_response.png)
 
 ## Get started
 
 This guide will help you setup an OAuth2 app in order to get authenticated & authorised to communicate with the Zepto API.
 
-
-
 **Before you start:**
 
+- We use the term **user** below but the user can be a third party or the same user that owns the OAuth2 application.
 
-* We use the term **user** below but the user can be a third party or the same user that owns the OAuth2 application.
-
-* As noted below, some access tokens expire every 2 hours. To get a new access token use the [refresh grant strategy](doc:zepto-api#authentication-and-authorisation) to swap a refresh token for a new access token.
-
+- As noted below, some access tokens expire every 2 hours. To get a new access token use the [refresh grant strategy](doc:zepto-api#authentication-and-authorisation) to swap a refresh token for a new access token.
 
 1. **Create a Zepto account**
 
-    If you haven't already, you'll want to create a sandbox Zepto account at [https://go.sandbox.zeptopayments.com](https://go.sandbox.zeptopayments.com).
+   If you haven't already, you'll want to create a sandbox Zepto account at <https://go.sandbox.zeptopayments.com>.
 
 2. **Choose authentication method**
 
-    All requests to the Zepto API require an `access_token` for authentication. There are two options for obtaining these tokens, the correct option will depend on your use case:
+   All requests to the Zepto API require an `access_token` for authentication. There are two options for obtaining these tokens, the correct option will depend on your use case:
 
-    **Personal access token** If you only need to access your own Zepto account via the API, then using personal access tokens are the most straight-forward way. Refer to [Personal access token](doc:zepto-api#personal-access-token) to setup. These tokens do not expire so no refreshing is required.
+   **Personal access token** If you only need to access your own Zepto account via the API, then using personal access tokens are the most straight-forward way. Refer to [Personal access token](doc:zepto-api#personal-access-token) to setup. These tokens do not expire so no refreshing is required.
 
-    **OAuth grant flow** When you require your application to act on behalf of other Zepto accounts you'll need to implement the OAuth grant flow process. Refer to [OAuth grant flow guide](doc:zepto-api#oauth-grant-flow) to setup. There is also an [OAuth grant flow tutorial](doc:zepto-api#oauth-grant-flow-tutorial). These access tokens expire every 2 hours, unless the `offline_access` scope is used in which case the tokens will not expire.
+   **OAuth grant flow** When you require your application to act on behalf of other Zepto accounts you'll need to implement the OAuth grant flow process. Refer to [OAuth grant flow guide](doc:zepto-api#oauth-grant-flow) to setup. There is also an [OAuth grant flow tutorial](doc:zepto-api#oauth-grant-flow-tutorial). These access tokens expire every 2 hours, unless the `offline_access` scope is used in which case the tokens will not expire.
 
 ## Personal access token
 
 If you're looking to only access your own account via the API, you can generate a personal access token from the UI. These tokens do not expire, but can be deleted.
 
-
-* To do this, sign in to your Zepto account and [create an application](https://go.sandbox.zeptopayments.com/oauth/applications) if you haven't already. Click on your application from your [application list](https://go.sandbox.zeptopayments.com/oauth/applications) and click on **Personal access**.
+- To do this, sign in to your Zepto account and [create an application](https://go.sandbox.zeptopayments.com/oauth/applications) if you haven't already. Click on your application from your [application list](https://go.sandbox.zeptopayments.com/oauth/applications) and click on **Personal access**.
 
     [![Zepto locate personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_tokens_empty.png)
 
@@ -200,154 +178,139 @@ If you're looking to only access your own account via the API, you can generate 
 
     [![Zepto personal OAuth2 tokens](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_personal_access_token.png)
 
-
-* Now that you have an `access_token` you can interact with your Zepto account via the API.
+- Now that you have an `access_token` you can interact with your Zepto account via the API.
 
     To do so, you must simply append the access token to the header of any API request: `Authorization: Bearer {access_token}`
-
-
 
 ## OAuth grant flow
 
 1. **Register your application with Zepto**
 
-    Once you've got your account up and running, sign in and create an OAuth2 profile for your application: [https://go.sandbox.zeptopayments.com/oauth/applications](https://go.sandbox.zeptopayments.com/oauth/applications)
+   Once you've got your account up and running, sign in and create an OAuth2 profile for your application: <https://go.sandbox.zeptopayments.com/oauth/applications>
 
-    | Parameter | Description |
-    |-----------|-------------|
-    | **Name**  | The name of your application. When using the *Authorisation Grant Flow*, users will see this name as the application requesting access to their account. |
-    | **Redirect URI** | Set this to your application's endpoint charged with receiving the authorisation code. |
+   | Parameter        | Description                                                                                                                                              |
+   | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Name**         | The name of your application. When using the _Authorisation Grant Flow_, users will see this name as the application requesting access to their account. |
+   | **Redirect URI** | Set this to your application's endpoint charged with receiving the authorisation code.                                                                   |
 
 2. **Obtain an authorisation code**
 
-    Construct the initial URL the user will need to visit in order to grant your application permission to act on his/her behalf. The constructed URL describes the level of permission ([`scope`](doc:zepto-api#scopes)), the application requesting permission (`client_id`) and where the user gets redirected once they've granted permission (`redirect_uri`).
+   Construct the initial URL the user will need to visit in order to grant your application permission to act on his/her behalf. The constructed URL describes the level of permission ([`scope`](doc:zepto-api#scopes)), the application requesting permission (`client_id`) and where the user gets redirected once they've granted permission (`redirect_uri`).
 
-    The URL should be formatted to look like this:
-    `https://go.sandbox.zeptopayments.com/oauth/authorize?response_type=code&client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}`
+   The URL should be formatted to look like this:  
+   `https://go.sandbox.zeptopayments.com/oauth/authorize?response_type=code&client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}`
 
-    | Parameter | Description |
-    |-----------|-------------|
-    | `response_type` | Always set to `code` |
-    | `client_id` | This is your `Application ID` as generated when you registered your application with Zepto |
-    | `redirect_uri` | URL where the user will get redirected along with the newly generated authorisation code |
-    | `scope` | The [scope](doc:zepto-api#scopes) of permission you're requesting |
+   | Parameter       | Description                                                                                |
+   | --------------- | ------------------------------------------------------------------------------------------ |
+   | `response_type` | Always set to `code`                                                                       |
+   | `client_id`     | This is your `Application ID` as generated when you registered your application with Zepto |
+   | `redirect_uri`  | URL where the user will get redirected along with the newly generated authorisation code   |
+   | `scope`         | The [scope](doc:zepto-api#scopes) of permission you're requesting                          |
 
 3. **Exchange the authorisation code for an access token**
 
-    When the user visits the above-mentioned URL, they will be presented with a Zepto login screen and then an authorisation screen:
+   When the user visits the above-mentioned URL, they will be presented with a Zepto login screen and then an authorisation screen:
 
-    [![Authorise OAuth2 app](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_authorize.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_authorize.png)
+   [![Authorise OAuth2 app](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_authorize.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_authorize.png)
 
-    After the user has authorised your application, they will be returned to your application at the URL specified in `redirect_uri` along with the `code` query parameter as the authorisation code.
+   After the user has authorised your application, they will be returned to your application at the URL specified in `redirect_uri` along with the `code` query parameter as the authorisation code.
 
-    Finally, the authorisation code can then be exchanged for an access token and refresh token pair by POSTing to: `https://go.sandbox.zeptopayments.com/oauth/token`
+   Finally, the authorisation code can then be exchanged for an access token and refresh token pair by POSTing to: `https://go.sandbox.zeptopayments.com/oauth/token`
 
-    **Note** The authorisation code is a ONE-TIME use code. It will not work again if you try to POST it a second time.
+   **Note** The authorisation code is a ONE-TIME use code. It will not work again if you try to POST it a second time.
 
-    | Parameter | Description |
-    |-----------|-------------|
-    | `grant_type` | Set to `authorization_code` |
-    | `client_id` | This is your `Application ID` as generated when you registered your application with Zepto |
-    | `client_secret` | This is your `Secret` as generated when you registered your application with Zepto |
-    | `code` | The authorisation code returned with the user (ONE-TIME use) |
-    | `redirect_uri` | Same URL used in step 3 |
+   | Parameter       | Description                                                                                |
+   | --------------- | ------------------------------------------------------------------------------------------ |
+   | `grant_type`    | Set to `authorization_code`                                                                |
+   | `client_id`     | This is your `Application ID` as generated when you registered your application with Zepto |
+   | `client_secret` | This is your `Secret` as generated when you registered your application with Zepto         |
+   | `code`          | The authorisation code returned with the user (ONE-TIME use)                               |
+   | `redirect_uri`  | Same URL used in step 3                                                                    |
 
 4. **Wrap-up**
 
-    Now that you have an access token and refresh token, you can interact with the Zepto API as the user related to the access token.
-    To do so, you must simply append the access token to the header of any API request: `Authorization: Bearer {access_token}`
-
+   Now that you have an access token and refresh token, you can interact with the Zepto API as the user related to the access token.  
+   To do so, you must simply append the access token to the header of any API request: `Authorization: Bearer {access_token}`
 
 ## OAuth grant flow tutorial
 
 The OAuth grant flow process is demonstrated using Postman in the steps below.
 
-
 Before you start, load up our API collection:
-
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/3168734-baa5ff70-4bc2-44d5-9ba6-fcb61839ff41?action=collection%2Ffork&collection-url=entityId%3D3168734-baa5ff70-4bc2-44d5-9ba6-fcb61839ff41%26entityType%3Dcollection%26workspaceId%3D6400ea2b-bb46-421e-a88c-a8625653c35a#?env%5BSplit%20Payments%20Public%20Sandbox%5D=W3sia2V5Ijoic2l0ZV9ob3N0IiwidmFsdWUiOiJodHRwczovL2dvLnNhbmRib3guc3BsaXQuY2FzaCIsImVuYWJsZWQiOnRydWV9LHsia2V5IjoiYXBpX2hvc3QiLCJ2YWx1ZSI6Imh0dHBzOi8vYXBpLnNhbmRib3guc3BsaXQuY2FzaCIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoib2F1dGgyX2FwcGxpY2F0aW9uX2lkIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6Im9hdXRoMl9zZWNyZXQiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoic2NvcGUiLCJ2YWx1ZSI6InB1YmxpYyBhZ3JlZW1lbnRzIGJhbmtfYWNjb3VudHMgYmFua19jb25uZWN0aW9ucyBjb250YWN0cyBwYXltZW50cyBwYXltZW50X3JlcXVlc3RzIHJlZnVuZF9yZXF1ZXN0cyB0cmFuc2FjdGlvbnMgcmVmdW5kcyBvcGVuX2FncmVlbWVudHMgb2ZmbGluZV9hY2Nlc3MiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6Imlzbzg2MDFfbm93IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFjY2Vzc190b2tlbiIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJyZWZyZXNoX3Rva2VuIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfV0=)
 
-
-**A screencast of this process is also available:
-[https://vimeo.com/246203244](https://vimeo.com/246203244).**
-
+**A screencast of this process is also available:  
+<https://vimeo.com/246203244>.**
 
 1. **Create a Zepto account**
 
-    If you haven't already, you'll want to create a sandbox Zepto account at [https://go.sandbox.zeptopayments.com](https://go.sandbox.zeptopayments.com)
+   If you haven't already, you'll want to create a sandbox Zepto account at <https://go.sandbox.zeptopayments.com>
 
 2. **Register your application with Zepto**
 
-    Sign in and create an OAuth2 application: [https://go.sandbox.zeptopayments.com/oauth/applications](https://go.sandbox.zeptopayments.com/oauth/applications).
+   Sign in and create an OAuth2 application: <https://go.sandbox.zeptopayments.com/oauth/applications>.
 
-    Use the special Postman callback URL: `https://www.getpostman.com/oauth2/callback`
+   Use the special Postman callback URL: `https://www.getpostman.com/oauth2/callback`
 
-    [![Zepto OAuth2 app setup](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_setup.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_setup.png)
+   [![Zepto OAuth2 app setup](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_setup.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/split_oauth2_app_setup.png)
 
 3. **In Postman, setup your environment variables**
 
-    We've included the **Zepto Public Sandbox** environment to get you started. Select it in the top right corner of the window then click the <img class="inline-1" alt="Postman Quick-Look icon" src="https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_quick_look_icon.png" /> icon and click **edit**.
+   We've included the **Zepto Public Sandbox** environment to get you started. Select it in the top right corner of the window then click the <img class="inline-1" alt="Postman Quick-Look icon" src="https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_quick_look_icon.png" /> icon and click **edit**.
 
+   [![Edit Postman environment](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_zepto_sandbox_environment.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_zepto_sandbox_environment.png)
 
-    [![Edit Postman environment](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_zepto_sandbox_environment.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_zepto_sandbox_environment.png)
+   Using the details from the OAuth2 app you created earlier, fill in the **oauth2_application_id** & **oauth2_secret** fields.
 
-    Using the details from the OAuth2 app you created earlier, fill in the **oauth2_application_id** & **oauth2_secret** fields.
-
-    [![Fill in environment values](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_zepto_environment_values.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_zepto_environment_values.png)
+   [![Fill in environment values](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_zepto_environment_values.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_zepto_environment_values.png)
 
 4. **Setup the authorization**
 
-    Click on the **Authorization** tab and select **OAuth 2.0**
+   Click on the **Authorization** tab and select **OAuth 2.0**
 
-    [![Postman Authorization tab](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_authorization_tab.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_authorization_tab.png)
+   [![Postman Authorization tab](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_authorization_tab.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_authorization_tab.png)
 
-    Click the **Get New Access Token** button
+   Click the **Get New Access Token** button
 
-    [![Postman get new access token](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_get_new_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_get_new_access_token.png)
+   [![Postman get new access token](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_get_new_access_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_get_new_access_token.png)
 
-    Fill in the OAuth2 form as below:
+   Fill in the OAuth2 form as below:
 
-    [![Postman OAuth2](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_oauth2_form.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_oauth2_form.png)
+   [![Postman OAuth2](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_oauth2_form.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_oauth2_form.png)
 
 5. **Get authorised**
 
-    Click **Request Token** and wait a few seconds and a browser window will popup
+   Click **Request Token** and wait a few seconds and a browser window will popup
 
-    Sign in with your Zepto account (or any other Zepto account you want to authorise).
+   Sign in with your Zepto account (or any other Zepto account you want to authorise).
 
-    [![Sign in Zepto to authorise via OAuth2](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_signin.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_signin.png)
+   [![Sign in Zepto to authorise via OAuth2](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_signin.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_signin.png)
 
-    Click **Authorise** to allow the app to access the signed in account. Once complete, Postman will automatically exchange the authorisation code it received from Zepto for the `access_token/refresh_token` pair. It will then store the `access_token/refresh_token` for you to use in subsequent API requests. The `access_token` effectively allows you to send requests via the API as the user who provided you authorisation.
+   Click **Authorise** to allow the app to access the signed in account. Once complete, Postman will automatically exchange the authorisation code it received from Zepto for the `access_token/refresh_token` pair. It will then store the `access_token/refresh_token` for you to use in subsequent API requests. The `access_token` effectively allows you to send requests via the API as the user who provided you authorisation.
 
-    [![Authorise OAuth2 app](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_authorize.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_authorize.png)
+   [![Authorise OAuth2 app](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_authorize.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/zepto_oauth2_authorize.png)
 
 6. **You're now ready to use the API**
 
-    Select an endpoint from the Zepto collection from the left hand side menu. Before you send an API request ensure you select your access token and Postman will automatically add it to the request header.
+   Select an endpoint from the Zepto collection from the left hand side menu. Before you send an API request ensure you select your access token and Postman will automatically add it to the request header.
 
-    [![Postman use token](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_token.png)
+   [![Postman use token](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_token.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/postman_use_token.png)
 
-> **_NOTE:_** Remember to select the access token everytime you try
-a new endpoint. Have fun!
-
+> **_NOTE:_** Remember to select the access token everytime you try  
+> a new endpoint. Have fun!
 
 ## Authentication and Authorisation
 
-
 Zepto uses OAuth2 over https to manage authentication and authorisation.
-
 
 OAuth2 is a protocol that lets external applications request permission from another Zepto user to send requests on their behalf without getting their password.
 
 This is preferred over Basic Authentication because access tokens can be limited by scope and can be revoked by the user at any time.
 
-
 New to OAuth2? DigitalOcean has a fantastic 5 minute [introduction to OAuth2](https://www.digitalocean.com/community/tutorials/an-introduction-to-oauth-2#grant-type-authorization-code).
 
-
 We currently support the **authorisation code** and **refresh token** grants.
-
 
 ### Authorisation Code Grant
 
@@ -355,18 +318,13 @@ This type of grant allows your application to act on behalf of a user. If you've
 
 Google, Twitter or Facebook account, this is the grant being used.
 
-
 See the [Get Started guide](doc:zepto-api#get-started) for step by step details on how to use this grant.
-
 
 ### Refresh Token Grant
 
-
 > Code sample
 
-
 ```
-
 curl -F "grant_type=refresh_token" \
       -F "client_id={{oauth2_application_id}}" \
       -F "client_secret={{oauth2_application_secret }}" \
@@ -374,9 +332,7 @@ curl -F "grant_type=refresh_token" \
       -X POST https://go.sandbox.zeptopayments.com/oauth/token
 ```
 
-
 > Example response
-
 
 ```json
 
@@ -390,81 +346,60 @@ curl -F "grant_type=refresh_token" \
 
 ```
 
-
 When using the authorisation code grant above, Zepto will return a `refresh token` along with the access token. Access tokens are short lived and last 2 hours but refresh tokens do not expire.
-
 
 When the access token expires, instead of sending the user back through the authorisation flow you can use the refresh token to retrieve a new access token with the same permissions as the old one.
 
-
-> **_NOTE:_**
-  The `refresh_token` gets regenerated and sent alongside the new `access_token`. In other words, `refresh_token`s are single use so you'll want to store the newly generated `refresh_token` everytime you use it to get a new `access_token`
-
-
+> **_NOTE:_**  
+>   The `refresh_token` gets regenerated and sent alongside the new `access_token`. In other words, `refresh_token`s are single use so you'll want to store the newly generated `refresh_token` everytime you use it to get a new `access_token`
 
 ## Making payments
 
 In order to payout funds, you'll be looking to use the [Payments](doc:zepto-api#Zepto-API-Payments) endpoint. Whether you're paying out another Zepto account holder or anyone, the process is the same:
 
-
 1. Add the recipient to your [Contact](doc:zepto-api#add-a-contact) list.
 
 2. [Make a Payment](doc:zepto-api#make-a-payment) to your Contact.
 
-
 Common use cases:
 
+- Automated payout disbursement (Referal programs, net/commission payouts, etc...)
 
-* Automated payout disbursement (Referal programs, net/commission payouts, etc...)
+- Wage payments
 
-* Wage payments
+- Gig economy payments
 
-* Gig economy payments
-
-* Lending
-
+- Lending
 
 ## Getting paid
 
-
 ### POSTing a [Payment Request](doc:zepto-api#Zepto-API-Payment-Requests)
-
 
 Provides the ability to send a Payment Request (get paid) to any Contact that has an accepted Agreement in place.
 
-
 To send a Payment Request to a Contact using the API, you must first have an accepted [Agreement](doc:zepto-api#Zepto-API-Agreements) with them.
-
 
 To do so, you can send them an [Open Agreement link](https://help.zepto.money/agreements/open-agreement) or [Unassigned Agreement link](http://help.zepto.money/agreements/unassigned-agreement) for them to [Select & verify their bank account](https://help.zepto.money/bank-accounts/instant-account-verification-iav) and accept the Agreement.
 
-
 Having this in place will allow any future Payment Requests to be automatically approved and processed as per the Agreement terms.
-
 
 Common use cases:
 
+- Subscriptions
 
-* Subscriptions
+- On-account balance payments
 
-* On-account balance payments
+- Bill smoothing
 
-* Bill smoothing
-
-* Repayment plans
-
+- Repayment plans
 
 Example flow embedding an [Open Agreement link](https://help.zepto.money/agreements/open-agreement) using an iFrame in order to automate future Payment Request approvals:
 
-
 [![Hosted Open Agreement](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/host_oa.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/host_oa.png)
-
 
 ## Idempotent requests
 
-
 > Example response
-
 
 ```json
 
@@ -485,47 +420,37 @@ Example flow embedding an [Open Agreement link](https://help.zepto.money/agreeme
 
 ```
 
-
 The Zepto API supports idempotency for safely retrying requests without accidentally performing the same operation twice.
 
 For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is a network connection error, you can retry the Payment with the same idempotency key to guarantee that only a single Payment is created. In case an idempotency key is not supplied and a Payment is retried, we would treat this as two different payments being made.
 
-
 To perform an idempotent request, provide an additional `Idempotency-Key:<key>` header to the request.
-
 
 You can pass any value (up to 256 characters) as the key but we suggest [V4 UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
 
-
 Keys expire after 24 hours. If there is a subsequent request with the same idempotency key within the 24 hour period, we will return a `409 Conflict`.
 
+- The `meta.resource_ref` value is the reference of the resource that was previously created with the conflicting idempotency key.
 
-* The `meta.resource_ref` value is the reference of the resource that was previously created with the conflicting idempotency key.
+- The `Idempotency-Key` header is optional but recommended.
 
-* The `Idempotency-Key` header is optional but recommended.
+- Only the `POST` action for the Payments, Payment Requests and Refunds endpoints support the use of the `Idempotency-Key`.
 
-* Only the `POST` action for the Payments, Payment Requests and Refunds endpoints support the use of the `Idempotency-Key`.
+- Endpoints that use the `GET` or `DELETE` actions are idempotent by nature.
 
-* Endpoints that use the `GET` or `DELETE` actions are idempotent by nature.
-
-* A request that quickly follows another with the same idempotency key may return with `503 Service Unavailable`. If so, retry the request after the number of seconds specified in the `Retry-After` response header.
-
+- A request that quickly follows another with the same idempotency key may return with `503 Service Unavailable`. If so, retry the request after the number of seconds specified in the `Retry-After` response header.
 
 Currently the following `POST` requests can be made idempotent. We **strongly recommend** sending a unique `Idempotency-Key` header when making those requests to allow for safe retries:
 
+- [Request Payment](doc:zepto-api#request-payment)
 
-* [Request Payment](doc:zepto-api#request-payment)
+- [Make a Payment](doc:zepto-api#make-a-payment)
 
-* [Make a Payment](doc:zepto-api#make-a-payment)
-
-* [Issue a Refund](doc:zepto-api#issue-a-refund)
-
+- [Issue a Refund](doc:zepto-api#issue-a-refund)
 
 ## Error responses
 
-
 > Example detailed error response
-
 
 ```json
 
@@ -545,7 +470,6 @@ Currently the following `POST` requests can be made idempotent. We **strongly re
 
 > Example resource error response
 
-
 ```json
 
 {
@@ -556,46 +480,37 @@ Currently the following `POST` requests can be made idempotent. We **strongly re
 
 The Zepto API returns two different types of error responses depending on the context.
 
-
 **Detailed error responses** are returned for:
 
+- Authentication
 
-* Authentication
+- Request types
 
-* Request types
-
-* Idempotency
-
+- Idempotency
 
 All other errors relating to Zepto specific resources(e.g. Contacts) will return the **Resource error response** style.
 
 ### 403 errors
 
-
 **403 errors** are generally returned from any of our endpoints if your application does not have the required authorisation. This is usually due to:
 
+- An [invalid/expired `access_token`](doc:zepto-api#authentication-and-authorisation); or
 
-* An [invalid/expired `access_token`](doc:zepto-api#authentication-and-authorisation); or
+- The required **scopes** not being present when setting up your [OAuth application](https://go.sandbox.zeptopayments.com/oauth/applications); or
 
-* The required **scopes** not being present when setting up your [OAuth application](https://go.sandbox.zeptopayments.com/oauth/applications); or
-
-* The required **scopes** not being present in the [authorisation code link](doc:zepto-api#oauth-grant-flow) used to present your user with an authorisation request.
-
+- The required **scopes** not being present in the [authorisation code link](doc:zepto-api#oauth-grant-flow) used to present your user with an authorisation request.
 
 ## Speeding up onboarding
 
 Consider the following scenario:
 
-
 > Zepto is integrated in your application to handle payments.
-
+>
 > A customer would like to use Zepto but does not yet have Zepto account.
-
+>
 > You already have some information about this customer.
 
-
 Given the above, in a standard implementation where a customer enables/uses Zepto within your application, these are the steps they would follow:
-
 
 1. Click on some sort of button within your app to use Zepto.
 
@@ -609,50 +524,41 @@ Given the above, in a standard implementation where a customer enables/uses Zept
 
 6. They would click the "Authorise" button and be redirected to your app.
 
-
 Whilst not too bad, we can do better!
-
 
 In order to speed up the process, we allow query string params to be appended to the [authorisation URL](doc:zepto-api#get-started). For instance, if we already have some information about the customer and know they probably don't have a Zepto account, we can embed this information in the authorisation URL.
 
-
 **Supported query string parameters**
 
-| Parameter | Description |
-|-----------|-------------|
-| `landing`   | Accepted value: `sign_up`. What page the user should see first if not already signed in Default is the sign in page.Deprecated values: `business_sign_up`, `personal_sign_up`.|
-| `nickname` | Only letters, numbers, dashes and underscores are permitted.
-This will be used to identify the account in Zepto. |
-| `name` | Business account only. Business name. |
-| `abn` | Business account only. Business ABN. |
-| `phone` | Business account only. Business phone number. |
-| `street_address` | |
-| `suburb` | |
-| `state` | See the sign up page for accepted values |
-| `postcode` | |
-| `first_name` | |
-| `last_name` | |
-| `mobile_phone` | |
-| `email` | |
-
+| Parameter                                           | Description                                                                                                                                                                    |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `landing`                                           | Accepted value: `sign_up`. What page the user should see first if not already signed in Default is the sign in page.Deprecated values: `business_sign_up`, `personal_sign_up`. |
+| `nickname`                                          | Only letters, numbers, dashes and underscores are permitted.                                                                                                                   |
+| This will be used to identify the account in Zepto. |                                                                                                                                                                                |
+| `name`                                              | Business account only. Business name.                                                                                                                                          |
+| `abn`                                               | Business account only. Business ABN.                                                                                                                                           |
+| `phone`                                             | Business account only. Business phone number.                                                                                                                                  |
+| `street_address`                                    |                                                                                                                                                                                |
+| `suburb`                                            |                                                                                                                                                                                |
+| `state`                                             | See the sign up page for accepted values                                                                                                                                       |
+| `postcode`                                          |                                                                                                                                                                                |
+| `first_name`                                        |                                                                                                                                                                                |
+| `last_name`                                         |                                                                                                                                                                                |
+| `mobile_phone`                                      |                                                                                                                                                                                |
+| `email`                                             |                                                                                                                                                                                |
 
 All values should be [URL encoded](https://en.wikipedia.org/wiki/Query_string#URL_encoding).
-
 
 As an example, the following authorisation URL would display the **personal sign up** & prefill the first name field with **George**:
 
 `https://go.sandbox.zeptopayments.com/oauth/authorize?response_type=code&client_id=xxx&redirect_uri=xxx&scope=xxx&landing=sign_up&first_name=George`
 
-
-You can also pass the values directly to the sign up page outside of the OAuth2 authorisation process. Click on the following link to see the values preloaded:
+You can also pass the values directly to the sign up page outside of the OAuth2 authorisation process. Click on the following link to see the values preloaded:  
 [https://go.sandbox.zeptopayments.com/business/sign_up?name=GeorgeCo&nickname=georgeco&first_name=George](https://go.sandbox.zeptopayments.com/business/sign_up?name=GeorgeCo&nickname=georgceco&first_name=George).
-
 
 # Sandbox Testing Details
 
-
 > Example failure object
-
 
 ```json
 
@@ -668,87 +574,76 @@ You can also pass the values directly to the sign up page outside of the OAuth2 
 
 Try out your happy paths and not-so happy paths; the sandbox is a great place to get started without transferring actual funds. All transactions are simulated and no communication with financial institutions is performed.
 
-
 The sandbox works on a 1 minute cycle to better illustrate how transactions are received and the lifecyle they go through. In other words, every minute, we simulate communicating with financial institutions and update statuses and events accordingly.
-
 
 All 6 digits BSBs are valid in the sandbox with the exception of `100000`. This BSB allows you to simulate the adding of an invalid BSB. In production, only real BSBs are accepted.
 
-
 Failed transactions will contain the following information inside the event:
 
+- Failure Code
 
-* Failure Code
+- Failure Title
 
-* Failure Title
-
-* Failure Details
-
+- Failure Details
 
 ## DE Transaction failures
 
 ### Using failure codes
 
-> * [DE credit failure codes]("#de-credit-failures")
-> * [DE debit failure codes]("#de-debit-failures)
-
-
+> - [DE credit failure codes]("#de-credit-failures")
+> - [DE debit failure codes]("#de-debit-failures)
 
 To simulate a transaction failure, create a Payment or Payment Request with an amount corresponding to the desired [failure code](#failure-codes).
 
-
 For example:
 
+- DE amount `$1.05` will cause the credit transaction to fail, triggering the credit failure code `E105` (Account Not Found).
 
-* DE amount `$1.05` will cause the credit transaction to fail, triggering the credit failure code `E105` (Account Not Found).
-
-* DE amount `$2.03` will cause the debit transaction to fail, triggering the debit failure code `E203` (Account Closed).
-
-
+- DE amount `$2.03` will cause the debit transaction to fail, triggering the debit failure code `E203` (Account Closed).
 
 ### Example scenarios
 
-  1. Pay a contact with an invalid account number:
-    * Initiate a Payment for `$1.05`.
-    * Zepto will mimic a successful debit from your bank account.
-    * Zepto will mimic a failure to credit the contact's bank account.
-    * Zepto will automatically create a `payout_reversal` credit transaction back to your bank account.
-  2. Request payment from a contact with a closed bank account:
-    * Initiate a Payment Request for `$2.03`.
-    * Zepto will mimic a failure to debit the contact's bank account.
+1. Pay a contact with an invalid account number:
 
+```
+* Initiate a Payment for `$1.05`.
+* Zepto will mimic a successful debit from your bank account.
+* Zepto will mimic a failure to credit the contact's bank account.
+* Zepto will automatically create a `payout_reversal` credit transaction back to your bank account.
+```
+
+2. Request payment from a contact with a closed bank account:
+
+```
+* Initiate a Payment Request for `$2.03`.
+* Zepto will mimic a failure to debit the contact's bank account.
+```
 
 ## NPP Payment failures
 
 ### Using failure codes
 
-> * [NPP credit failure codes]("#npp-credit-failures")
+> - [NPP credit failure codes](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_81961f33a0)
 
-
-To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures).
+To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures)
 
 For example:
 
+- NPP amount `$3.02` will cause the transaction to fail, triggering credit failure code `E302` (BSB Not NPP Enabled).
 
-* NPP amount `$3.02` will cause the transaction to fail, triggering credit failure code `E302` (BSB Not NPP Enabled).
-
-* NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
-
+- NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
 
 You will receive all the same notifications as if this happened in our live environment. We recommend you check out our article on [what happens when an NPP Payment fails](https://help.zepto.money/en/articles/4405560-what-happens-when-an-npp-payment-fails) to learn more about what happens when an NPP Payment is unable to process.
 
-
 ## Instant account verification accounts
 
-When using any of our hosted solutions ([Payment Requests](https://help.zepto.money/en/?q=payment+request),
-[Open Agreements](https://help.zepto.money/agreements/open-agreement) or
+When using any of our hosted solutions ([Payment Requests](https://help.zepto.money/en/?q=payment+request),  
+[Open Agreements](https://help.zepto.money/agreements/open-agreement) or  
 [Unassigned Agreements](http://help.zepto.money/agreements/unassigned-agreement)) you may want to test the [Instant Account Verification (IAV)](http://help.zepto.money/bank-accounts/instant-account-verification-iav) process where we accept online banking credentials to validate bank account access. To do so, you can use the following credentials:
 
-
-| Login | Password |
-|-------|----------|
+| Login      | Password      |
+| ---------- | ------------- |
 | `12345678` | `TestMyMoney` |
-
 
 > **_NOTE:_** The credentials will work with any of the available financial institutions.
 
@@ -758,39 +653,34 @@ When using any of our hosted solutions ([Payment Requests](https://help.zepto.mo
 
 Scopes define the level of access granted via the OAuth2 authorisation process. As a best practice, only use the scopes your application will require.
 
+| Scope              | Description                                |
+| ------------------ | ------------------------------------------ |
+| `public`           | View user's public information             |
+| `agreements`       | Manage user's Agreements                   |
+| `bank_accounts`    | Manage user's Bank Accounts                |
+| `bank_connections` | Manage user's Bank Connections             |
+| `contacts`         | Manage user's Contacts                     |
+| `open_agreements`  | Manage user's Open Agreements              |
+| `payments`         | Manage user's Payments                     |
+| `payment_requests` | Manage user's Payment Requests             |
+| `refunds`          | Manage user's Refunds                      |
+| `transfers`        | Manage user's Transfers                    |
+| `transactions`     | Access user's Transactions                 |
+| `webhooks`         | Manage user's Webhook events               |
+| `offline_access`   | Create non-expiring access tokens for user |
 
-| Scope | Description |
-|--------|------------|
-| `public` | View user's public information |
-| `agreements` | Manage user's Agreements |
-| `bank_accounts` | Manage user's Bank Accounts |
-| `bank_connections` | Manage user's Bank Connections |
-| `contacts` | Manage user's Contacts |
-| `open_agreements` | Manage user's Open Agreements |
-| `payments` | Manage user's Payments |
-| `payment_requests` | Manage user's Payment Requests |
-| `refunds` | Manage user's Refunds |
-| `transfers` | Manage user's Transfers |
-| `transactions` | Access user's Transactions |
-| `webhooks` | Manage user's Webhook events |
-| `offline_access` | Create non-expiring access tokens for user |
-
-  > **_NOTE:_** Please use `offline_access` with discretion, as you'll have no direct way to invalidate the token. Please contact Zepto immediately if any token may have potentially been compromised.
+> **_NOTE:_** Please use `offline_access` with discretion, as you'll have no direct way to invalidate the token. Please contact Zepto immediately if any token may have potentially been compromised.
 
 ## Pagination
 
-
 > Example response headers
 
-
 ```
-
 Link: <http://api.sandbox.zeptopayments.com/contacts?page=2>; rel="next"
 
 Per-Page: 25
 
 ```
-
 
 Pagination information can be located in the response headers: `Link` & `Per-Page`
 
@@ -798,23 +688,17 @@ All collection endpoints are paginated to `Per-Page: 25` by default. (`100` per 
 
 You can control the pagination by including `per_page=x` and/or `page=x` in the endpoint URL params.
 
-
 The `Link` header will be optionally present if a "next page" is available to navigate to. The next page link is identified with `rel="next"`
-
 
 >  **Legacy Pagination**: Some existing users may still be on a transitional legacy version of pagination.
 >
 >  The Legacy version returns some extra **deprecated header values: `Total` plus `rel="last"` & `rel="prev"` in `Link`**.
 >
 >  Please transition to only using the `rel="next"` from the `Link` header, as all other values are deprecated.
->
-
 
 ## Remitter
 
-
 > Example request
-
 
 ```json
 
@@ -827,23 +711,17 @@ The `Link` header will be optionally present if a "next page" is available to na
 
 ```
 
-
 You can elect to assign a remitter name on a per-request basis when submitting Payments & Payment Requests. Simply append the `remitter` key and a value within the `metadata` key.
 
+- **For Payments**, the party being credited will see the designated remitter name along the entry on their bank statement.
 
-* **For Payments**, the party being credited will see the designated remitter name along the entry on their bank statement.
-
-* **For Payment Requests**, the party being debited will see the designated remitter name along the entry on their bank statement.
-
+- **For Payment Requests**, the party being debited will see the designated remitter name along the entry on their bank statement.
 
 > **_NOTE:_** The remitter name MUST be between `3` and `16` characters.
 
-
 ## Aggregation
 
-
 Zepto will automatically aggregate debits that are:
-
 
 - From the same bank account; and
 
@@ -853,22 +731,17 @@ Zepto will automatically aggregate debits that are:
 
 Likewise for credits:
 
-
 - To the same bank account; and
 
 - Have the same description; and
 
 - Initiated by the same Zepto account.
 
-
 Should you prefer debit aggregation to be disabled, please contact [support@zepto.com.au](mailto:support@zepto.com.au). Note that additional charges may apply.
-
 
 ## Webhooks
 
-
 > Example response
-
 
 ```json
 
@@ -890,44 +763,38 @@ Should you prefer debit aggregation to be disabled, please contact [support@zept
 
 Please refer to our help centre [article on webhooks](http://help.zepto.money/en/articles/3303626-webhooks) for more information and an overview of what you can achieve with webhooks.
 
-
 We support two main categories of webhooks:
-
 
 1. **Owner**: These webhooks are managed by the owner of the Zepto account and only report on events owned by the Zepto account.
 
 2. **App**: These webhooks are managed by the Zepto OAuth2 application owner and will report on events relating to any authorised Zepto account (limited by scope).
 
-
-| Name | Type | Required | Description |
-|-|-|-|-|
-| event | object | true | Webhook event details |
-| » type | string | true | The webhook event key (list available in the webhook settings) |
-| » at | string(date-time) | true | When the event occurred |
-| » who | object | true | Who the webhook event relates to |
-| »» account_id | string(uuid) | true | The Zepto account who's the owner of the event |
-| »» bank_account_id | string(uuid) | true | The above Zepto account's bank account |
-| data | [object] | true | Array of response bodies |
-
+| Name               | Type              | Required | Description                                                    |
+| ------------------ | ----------------- | -------- | -------------------------------------------------------------- |
+| event              | object            | true     | Webhook event details                                          |
+| » type             | string            | true     | The webhook event key (list available in the webhook settings) |
+| » at               | string(date-time) | true     | When the event occurred                                        |
+| » who              | object            | true     | Who the webhook event relates to                               |
+| »» account_id      | string(uuid)      | true     | The Zepto account who's the owner of the event                 |
+| »» bank_account_id | string(uuid)      | true     | The above Zepto account's bank account                         |
+| data               | [object]          | true     | Array of response bodies                                       |
 
 ### Data schemas
 
 Use the following table to discover what type of response schema to expect for for the `data.[{}]` component of the webhook delivery.
 
-
-| Event                    | Data schema                                                               |
-|--------------------------|---------------------------------------------------------------------------|
-| `agreement.*`            | [GetAnAgreementResponse](ref:getagreement)                                |
-| `contact.*`              | [GetAContactResponse](ref:getacontact)                                    |
-| `credit.*`               | [ListAllTransactionsResponse](ref:listalltransactions)                    |
-| `creditor_debit.*`       | [ListAllTransactionsResponse](ref:listalltransactions)                    |
-| `debit.*`                | [ListAllTransactionsResponse](ref:listalltransactions)                    |
-| `debtor_credit.*`        | [ListAllTransactionsResponse](ref:listalltransactions)                    |
-| `open_agreement.*`       | [ListAllOpenAgreementsRespose](ref:listallopenagreements)                 |
-| `payment.*`              | [GetAPaymentResponse](ref:getapayment)                                    |
-| `payment_request.*`      | [GetAPaymentRequestResponse](ref:getapaymentrequest)                      |
-| `unassigned_agreement.*` | [GetAnUnassignedAgreementResponse](ref:getunassignedagreement)            |
-
+| Event                    | Data schema                                                    |
+| ------------------------ | -------------------------------------------------------------- |
+| `agreement.*`            | [GetAnAgreementResponse](ref:getagreement)                     |
+| `contact.*`              | [GetAContactResponse](ref:getacontact)                         |
+| `credit.*`               | [ListAllTransactionsResponse](ref:listalltransactions)         |
+| `creditor_debit.*`       | [ListAllTransactionsResponse](ref:listalltransactions)         |
+| `debit.*`                | [ListAllTransactionsResponse](ref:listalltransactions)         |
+| `debtor_credit.*`        | [ListAllTransactionsResponse](ref:listalltransactions)         |
+| `open_agreement.*`       | [ListAllOpenAgreementsRespose](ref:listallopenagreements)      |
+| `payment.*`              | [GetAPaymentResponse](ref:getapayment)                         |
+| `payment_request.*`      | [GetAPaymentRequestResponse](ref:getapaymentrequest)           |
+| `unassigned_agreement.*` | [GetAnUnassignedAgreementResponse](ref:getunassignedagreement) |
 
 ### Our Delivery Promises
 
@@ -939,61 +806,44 @@ Use the following table to discover what type of response schema to expect for f
 
 4. We guarantee at least 1 delivery attempt.
 
-
 **For redelivery of webhooks, check out our [Webhook/WebhookDelivery API endpoints](#Zepto-API-Webhooks).**
 
 > **_NOTE:_** In the sandbox environment, webhook deliveries will only be retried once, to allow for easier testing of failure scenarios.
 
-
-
 ### Request ID
-
 
 > Example header
 
-
 ```
-
 Split-Request-ID: 07f4e8c1-846b-5ec0-8a25-24c3bc5582b5
 
 ```
 
-
 Zepto provides a `Split-Request-ID` header in the form of a `UUID` which uniquely identifies a webhook event. If the webhook event is retried/retransmitted by Zepto, the UUID will remain the same. This allows you to check if a webhook event has been previously handled/processed.
-
 
 ### Checking Webhook Signatures
 
-
 > Example header
 
-
 ```
-
 Split-Signature:
 1514772000.93eee90206280b25e82b38001e23961cba4c007f4d925ba71ecc2d9804978635
 
 ```
 
-
 Zepto signs the webhook events it sends to your endpoints. We do so by including a signature in each event’s `Split-Signature` header. This allows you to validate that the events were indeed sent by Zepto.
-
 
 Before you can verify signatures, you need to retrieve your endpoint’s secret from your Webhooks settings. Each endpoint has its own unique secret; if you use multiple endpoints, you must obtain a secret for each one.
 
-
 The `Split-Signature` header contains a timestamp and one or more signatures. All separated by `.` (dot).
 
-
 > Example code
-
 
 ```sh
 
 # Shell example is not available
 
 ```
-
 
 ```go
 
@@ -1028,7 +878,6 @@ func main() {
 }
 
 ```
-
 
 ```python
 
@@ -1069,7 +918,6 @@ print(given_signature)
 
 ```
 
-
 ```ruby
 
 require 'openssl'
@@ -1100,7 +948,6 @@ puts(given_signature)
 # => f04cb05adb985b29d84616fbf3868e8e58403ff819cdc47ad8fc47e6acbce29f
 
 ```
-
 
 ```javascript
 
@@ -1139,7 +986,6 @@ console.log(givenSignature)
 
 ```
 
-
 ```php
 
 $split_signature = '1514772000.f04cb05adb985b29d84616fbf3868e8e58403ff819cdc47ad8fc47e6acbce29f';
@@ -1166,7 +1012,6 @@ echo $given_signature;
 
 
 ```
-
 
 ```java
 
@@ -1212,6 +1057,9 @@ class Main {
 ```
 
 <!--
+
+ 
+
 This example is commented out since the docs do not include C#
 
 ```csharp
@@ -1248,28 +1096,22 @@ class MainClass {
 
 ```
 
--->
-
+\-->
 
 **Step 1. Extract the timestamp and signatures from the header**
 
-
 Split the header, using the `.` (dot) character as the separator, to get a list of elements.
 
-
-| Element | Description |
-|---------|-------------|
-| `timestamp` | [Unix time](https://en.wikipedia.org/wiki/Unix_time) in
-seconds when the signature was created |
-| `signature` | Request signature |
-| `other`     | Placeholder for future parameters (currently not used) |
-
+| Element                                | Description                                             |
+| -------------------------------------- | ------------------------------------------------------- |
+| `timestamp`                            | [Unix time](https://en.wikipedia.org/wiki/Unix_time) in |
+| seconds when the signature was created |                                                         |
+| `signature`                            | Request signature                                       |
+| `other`                                | Placeholder for future parameters (currently not used)  |
 
 **Step 2: Prepare the signed_payload string**
 
-
 You achieve this by concatenating:
-
 
 - The timestamp from the header (as a string)
 
@@ -1277,23 +1119,16 @@ You achieve this by concatenating:
 
 - The actual JSON payload (request body)
 
-
 **Step 3: Determine the expected signature**
-
 
 Compute an HMAC with the SHA256 hash function. Use the endpoint’s signing secret as the key, and use the `signed_payload` string as the message.
 
-
 **Step 4: Compare signatures**
-
 
 Compare the signature in the header to the expected signature. If a signature matches, compute the difference between the current timestamp and the received timestamp, then decide if the difference is within your tolerance.
 
-
 To protect against timing attacks, use a constant-time string comparison to compare the expected signature to each of the received signatures.
-
 
 > **_NOTE:_** The sandbox environment allow both HTTP and HTTPS webhook URLs. The live environment however will only POST to HTTPS URLs.
 
-
-Looking for more? Our docs are open sourced! [https://github.com/zeptofs/api-documentation](https://github.com/zeptofs/api-documentation)
+Looking for more? Our docs are open sourced! <https://github.com/zeptofs/api-documentation>


### PR DESCRIPTION
### Context

The Markdown formatting in Zepto API contains double newlines between each list item. 

I believe this was necessary for our old API doc site, but it's not required for readme.com. 

### Change
- Sync with readme.com (copy from web UI). This revealed that some extra newlines were removed and therefore not required (IIRC 3 newlines were previously required in some places). 
- Apply [Prettier](https://prettier.io/) formatting. 
- Remove double-newlines between list items. 
- Remove unintentional code block. 