### PR TITLE
[CENT-1201] Fix broken links in documentation

### DIFF
--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -360,7 +360,7 @@ Example flow embedding an [Open Agreement link](https://help.zepto.money/agreeme
 
 The Zepto API supports idempotency for safely retrying requests without accidentally performing the same operation twice.
 
-For example, if a [Payment](https://docs.zeptopayments.com/reference/makeapayment) is `POST`ed and a there is a network connection error, you can retry the Payment with the same idempotency key to guarantee that only a single Payment is created. In case an idempotency key is not supplied and a Payment is retried, we would treat this as two different payments being made.
+For example, if a [Make a Payment] is `POST`ed and a there is a network connection error, you can retry the Payment with the same idempotency key to guarantee that only a single Payment is created. In case an idempotency key is not supplied and a Payment is retried, we would treat this as two different payments being made.
 
 To perform an idempotent request, provide an additional `Idempotency-Key:<key>` header to the request.
 

--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -317,7 +317,7 @@ Common use cases:
 
 Provides the ability to send a Payment Request (get paid) to any Contact that has an accepted Agreement in place.
 
-To send a Payment Request to a Contact using the API, you must first have an accepted [Agreement](https://help.zepto.money/en/articles/3094575-au-agreements) with them.
+To send a Payment Request to a Contact using the API, you must first have an accepted [Agreement](https://docs.zeptopayments.com/reference/listoutgoingagreements) with them.
 
 To do so, you can send them an [Open Agreement link](https://help.zepto.money/agreements/open-agreement) or [Unassigned Agreement link](http://help.zepto.money/agreements/unassigned-agreement) for them to [Select & verify their bank account](https://help.zepto.money/bank-accounts/instant-account-verification-iav) and accept the Agreement.
 

--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -317,7 +317,7 @@ Common use cases:
 
 Provides the ability to send a Payment Request (get paid) to any Contact that has an accepted Agreement in place.
 
-To send a Payment Request to a Contact using the API, you must first have an accepted [Agreement](doc:zepto-api#Zepto-API-Agreements) with them.
+To send a Payment Request to a Contact using the API, you must first have an accepted [Agreement](https://help.zepto.money/en/articles/3094575-au-agreements) with them.
 
 To do so, you can send them an [Open Agreement link](https://help.zepto.money/agreements/open-agreement) or [Unassigned Agreement link](http://help.zepto.money/agreements/unassigned-agreement) for them to [Select & verify their bank account](https://help.zepto.money/bank-accounts/instant-account-verification-iav) and accept the Agreement.
 
@@ -360,11 +360,11 @@ Example flow embedding an [Open Agreement link](https://help.zepto.money/agreeme
 
 The Zepto API supports idempotency for safely retrying requests without accidentally performing the same operation twice.
 
-For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is a network connection error, you can retry the Payment with the same idempotency key to guarantee that only a single Payment is created. In case an idempotency key is not supplied and a Payment is retried, we would treat this as two different payments being made.
+For example, if a [Payment](https://docs.zeptopayments.com/reference/makeapayment) is `POST`ed and a there is a network connection error, you can retry the Payment with the same idempotency key to guarantee that only a single Payment is created. In case an idempotency key is not supplied and a Payment is retried, we would treat this as two different payments being made.
 
 To perform an idempotent request, provide an additional `Idempotency-Key:<key>` header to the request.
 
-You can pass any value (up to 256 characters) as the key but we suggest [V4 UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
+You can pass any value (up to 256 characters) as the key but we suggest [V7 UUIDs](https://uuid7.com/) or another appropriately random string.
 
 Keys expire after 24 hours. If there is a subsequent request with the same idempotency key within the 24 hour period, we will return a `409 Conflict`.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -370,7 +370,7 @@ For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is a ne
 
 To perform an idempotent request, provide an additional `Idempotency-Key: <key>` header to the request.
 
-You can pass any value (up to 256 characters) as the key but we suggest [V4 UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
+You can pass any value (up to 256 characters) as the key but we suggest [V7 UUIDs](https://uuid7.com/) or another appropriately random string.
 
 Keys expire after 24 hours. If there is a subsequent request with the same idempotency key within the 24 hour period, we will return a `409 Conflict`.
 
@@ -382,10 +382,10 @@ Keys expire after 24 hours. If there is a subsequent request with the same idemp
 
 Currently the following `POST` requests can be made idempotent. We **strongly recommend** sending a unique `Idempotency-Key` header when making those requests to allow for safe retries:
 
-* [Request Payment](/#request-payment)
-* [Make a Payment](/#make-a-payment)
-* [Issue a Refund](/#issue-a-refund)
-* [Add a Transfer](/#add-a-transfer)
+* [Request Payment](https://docs.zeptopayments.com/reference/makeapaymentrequest)
+* [Make a Payment](https://docs.zeptopayments.com/reference/makeapayment)
+* [Issue a Refund](https://docs.zeptopayments.com/reference/issuearefund)
+* [Add a Transfer](https://docs.zeptopayments.com/reference/addatransfer)
 
 ## Error responses
 
@@ -671,7 +671,7 @@ Use the following table to discover what type of response schema to expect for f
 3. Delivery order for webhook events is not guaranteed.
 4. We guarantee at least 1 delivery attempt.
 
-**For redelivery of webhooks, check out our [Webhook/WebhookDelivery API endpoints](#Zepto-API-Webhooks).**
+**For redelivery of webhooks, check out our [Webhook/WebhookDelivery API endpoints](https://docs.zeptopayments.com/reference/resendawebhookdelivery).**
 <aside class="notice">
   In the sandbox environment, webhook deliveries will only be retried once,
   to allow for easier testing of failure scenarios.
@@ -2732,7 +2732,7 @@ You can update the name, email, bank account and metadata of any Contact.
     <li>Previous transactions to this Contact will retain the name and bank account that was used at the time.</li>
     <li>You cannot update a Contact's bank account details if they currently have an accepted agreement.</li>
     <li>Any active Bank Connections will be lost if you change the Contact's bank account.</li>
-    <li>See our [Help Article](https://help.zepto.money/en/articles/3829211-how-do-i-change-my-customers-bank-account-details) for more information about the nuances and implications of changing a contacts Bank Account.</li>
+    <li>See our <a href="https://help.zepto.money/en/articles/3829211-how-do-i-change-my-customers-bank-account-details">Help Article</a> for more information about the nuances and implications of changing a contacts Bank Account.</li>
   </ul>
 </aside>
 
@@ -2991,7 +2991,7 @@ Receive funds from a Contact by allowing them to pay to a personalised PayID or 
   You can simulate this path in sandbox by adding <code>+failure</code> to your <code>payid_email</code> e.g <code>test+failure@zeptopayments.com</code>
 </aside>
 <aside class="notice">
-  You can test receiving payments to a Receivable Contact in our sandbox environment using the <a href="#simulate-incoming-payid-payment">PayID simulation endpoint</a>.
+  You can test receiving payments to a Receivable Contact in our sandbox environment using the <a href="https://docs.zeptopayments.com/reference/simulateincomingpayidpayment">PayID simulation endpoint</a>.
 </aside>
 
 > Body parameter
@@ -3736,7 +3736,7 @@ func main() {
 
 `POST /payment_requests`
 
-<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="https://docs.zeptopayments.com/docs/zepto-api#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 
@@ -4474,7 +4474,7 @@ func main() {
 
 `GET /payment_requests/receivables`
 
-Payment Requests where the debtor is sending you funds ([Receivable Contacts](/#add-a-receivable-contact)). This endpoint exposes all received payments.
+Payment Requests where the debtor is sending you funds ([Receivable Contacts](https://docs.zeptopayments.com/reference/addareceivablecontact)). This endpoint exposes all received payments.
 
 <h3 id="List-Receivables-parameters" class="parameters">Parameters</h3>
 
@@ -4789,7 +4789,7 @@ To enable custom payment flows, the required payment channel can be selected by 
   <li>["direct_entry"] - for slower traditional payments</li>
   <li>["new_payments_platform", "direct_entry"] - enables automatic channel switching if a payment fails on the NPP</li>
 </ul>
-<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="https://docs.zeptopayments.com/docs/zepto-api#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 
@@ -5636,7 +5636,7 @@ Certain rules apply to the issuance of a refund:
   <li>Many refunds may be created against the original Payment Request</li>
   <li>The total refunded amount must not exceed the original value</li>
 </ul>
-<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+<aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="https://docs.zeptopayments.com/docs/zepto-api#idempotent-requests">Idempotent requests guide</a>.</aside>
 
 > Body parameter
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5468,7 +5468,7 @@ This allows you to return any funds that were previously collected or received i
 
 ```shell
 curl --request POST \
-  --url https://api.sandbox.zeptopayments.com/credits/string/refunds \
+  --url https://api.sandbox.zeptopayments.com/credits/C.625v/refunds \
   --header 'accept: application/json' \
   --header 'authorization: Bearer {access-token}' \
   --header 'content-type: application/json' \
@@ -5480,7 +5480,7 @@ curl --request POST \
 require 'uri'
 require 'net/http'
 
-url = URI("https://api.sandbox.zeptopayments.com/credits/string/refunds")
+url = URI("https://api.sandbox.zeptopayments.com/credits/C.625v/refunds")
 
 http = Net::HTTP.new(url.host, url.port)
 http.use_ssl = true
@@ -5504,7 +5504,7 @@ var options = {
   "method": "POST",
   "hostname": "api.sandbox.zeptopayments.com",
   "port": null,
-  "path": "/credits/string/refunds",
+  "path": "/credits/C.625v/refunds",
   "headers": {
     "content-type": "application/json",
     "accept": "application/json",
@@ -5550,7 +5550,7 @@ headers = {
     'authorization': "Bearer {access-token}"
     }
 
-conn.request("POST", "/credits/string/refunds", payload, headers)
+conn.request("POST", "/credits/C.625v/refunds", payload, headers)
 
 res = conn.getresponse()
 data = res.read()
@@ -5559,7 +5559,7 @@ print(data.decode("utf-8"))
 ```
 
 ```java
-HttpResponse<String> response = Unirest.post("https://api.sandbox.zeptopayments.com/credits/string/refunds")
+HttpResponse<String> response = Unirest.post("https://api.sandbox.zeptopayments.com/credits/C.625v/refunds")
   .header("content-type", "application/json")
   .header("accept", "application/json")
   .header("idempotency-key", "{unique-uuid-per-refund}")
@@ -5577,7 +5577,7 @@ $request = new http\Client\Request;
 $body = new http\Message\Body;
 $body->append('{"amount":500,"channels":["direct_entry"],"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}');
 
-$request->setRequestUrl('https://api.sandbox.zeptopayments.com/credits/string/refunds');
+$request->setRequestUrl('https://api.sandbox.zeptopayments.com/credits/C.625v/refunds');
 $request->setRequestMethod('POST');
 $request->setBody($body);
 
@@ -5606,7 +5606,7 @@ import (
 
 func main() {
 
-	url := "https://api.sandbox.zeptopayments.com/credits/string/refunds"
+	url := "https://api.sandbox.zeptopayments.com/credits/C.625v/refunds"
 
 	payload := strings.NewReader("{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -2670,6 +2670,7 @@ paths:
           style: simple
           schema:
             type: string
+          example: C.625v
       requestBody:
         description: ''
         content:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -522,8 +522,8 @@ info:
     <key>` header to the request.
 
 
-    You can pass any value (up to 256 characters) as the key but we suggest [V4
-    UUIDs](https://www.uuidtools.com/generate/v4) or another appropriately random string.
+    You can pass any value (up to 256 characters) as the key but we suggest [V7
+    UUIDs](https://uuid7.com/) or another appropriately random string.
 
 
     Keys expire after 24 hours. If there is a subsequent request with the same
@@ -550,13 +550,13 @@ info:
     when making those requests to allow for safe retries:
 
 
-    * [Request Payment](/#request-payment)
+    * [Request Payment](https://docs.zeptopayments.com/reference/makeapaymentrequest)
 
-    * [Make a Payment](/#make-a-payment)
+    * [Make a Payment](https://docs.zeptopayments.com/reference/makeapayment)
 
-    * [Issue a Refund](/#issue-a-refund)
+    * [Issue a Refund](https://docs.zeptopayments.com/reference/issuearefund)
 
-    * [Add a Transfer](/#add-a-transfer)
+    * [Add a Transfer](https://docs.zeptopayments.com/reference/addatransfer)
 
 
     ## Error responses
@@ -1045,7 +1045,7 @@ info:
     4. We guarantee at least 1 delivery attempt.
 
 
-    **For redelivery of webhooks, check out our [Webhook/WebhookDelivery API endpoints](#Zepto-API-Webhooks).**
+    **For redelivery of webhooks, check out our [Webhook/WebhookDelivery API endpoints](https://docs.zeptopayments.com/reference/resendawebhookdelivery).**
 
     <aside class="notice">
       In the sandbox environment, webhook deliveries will only be retried once,
@@ -2093,7 +2093,7 @@ paths:
           You can simulate this path in sandbox by adding <code>+failure</code> to your <code>payid_email</code> e.g <code>test+failure@zeptopayments.com</code>
         </aside>
         <aside class="notice">
-          You can test receiving payments to a Receivable Contact in our sandbox environment using the <a href="#simulate-incoming-payid-payment">PayID simulation endpoint</a>.
+          You can test receiving payments to a Receivable Contact in our sandbox environment using the <a href="https://docs.zeptopayments.com/reference/simulateincomingpayidpayment">PayID simulation endpoint</a>.
         </aside>
       operationId: AddAReceivableContact
       parameters: []
@@ -2348,7 +2348,7 @@ paths:
             <li>Previous transactions to this Contact will retain the name and bank account that was used at the time.</li>
             <li>You cannot update a Contact's bank account details if they currently have an accepted agreement.</li>
             <li>Any active Bank Connections will be lost if you change the Contact's bank account.</li>
-            <li>See our [Help Article](https://help.zepto.money/en/articles/3829211-how-do-i-change-my-customers-bank-account-details) for more information about the nuances and implications of changing a contacts Bank Account.</li>
+            <li>See our <a href="https://help.zepto.money/en/articles/3829211-how-do-i-change-my-customers-bank-account-details">Help Article</a> for more information about the nuances and implications of changing a contacts Bank Account.</li>
           </ul>
         </aside>
       operationId: UpdateAContact
@@ -2392,7 +2392,7 @@ paths:
           <li>["new_payments_platform", "direct_entry"] - enables automatic channel switching if a payment fails on the NPP</li>
         </ul>
 
-        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="https://docs.zeptopayments.com/docs/zepto-api#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPayment
       parameters:
         - name: 'Idempotency-Key'
@@ -2499,7 +2499,7 @@ paths:
         - Payment Requests
       summary: Request Payment
       description: >
-        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="https://docs.zeptopayments.com/docs/zepto-api#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPaymentRequest
       parameters:
         - name: 'Idempotency-Key'
@@ -2609,7 +2609,7 @@ paths:
       tags:
         - Payment Requests
       summary: 'List Receivables'
-      description: Payment Requests where the debtor is sending you funds ([Receivable Contacts](/#add-a-receivable-contact)).
+      description: Payment Requests where the debtor is sending you funds ([Receivable Contacts](https://docs.zeptopayments.com/reference/addareceivablecontact)).
                   This endpoint exposes all received payments.
       operationId: ListPaymentRequestReceivables
       parameters:
@@ -2653,7 +2653,7 @@ paths:
           <li>The total refunded amount must not exceed the original value</li>
         </ul>
 
-        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
+        <aside class="notice">We strongly recommend supplying an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="https://docs.zeptopayments.com/docs/zepto-api#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: IssueARefund
       parameters:
         - name: 'Idempotency-Key'


### PR DESCRIPTION
This PR fixes a number of broken links present in Zepto's documentation.  I scanned the content in **Developer Guides** and **API Reference** to find links that didn't work.  Safest solution seems to be hard coding them for now. 

I updated references to use UUID v4 over to UUID v7.

Finally I updated the Issue a Refund endpoint to make it slightly less confusing, giving it a default `example` value for selection.

### Before (confusing):


https://github.com/user-attachments/assets/ca6dfd7f-29a8-4679-b163-baf611c3f997


### After:

Adding an `example: ` value will allow a `credit_ref` value to be visible as a drop down option.  Still confusing, but less so. 

----

Note: an ideal state for the ReadMe docs would be getting API examples like `Issue a Refund` [to render how ReadMe's example API's do](https://docs.readme.com/main/reference/getapiregistry).  Where in ReadMe's version, a placeholder `uuid` string appears in the url path by default:
<img width="441" alt="Screenshot 2025-01-10 at 7 04 05 PM" src="https://github.com/user-attachments/assets/b989ec72-7069-4879-833b-be6ddec00eed" />

[The OpenAPI3 spec isn't clear](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object) how ReadMe achieves this.  Any insight appreciated!