### PR TITLE
update description for reason field in IssueARefund endpoint

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5664,7 +5664,7 @@ Certain rules apply to the issuance of a refund:
 |body|body|[IssueARefundRequest](#schemaissuearefundrequest)|true|No description|
 |» amount|body|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|
 |» channels|body|array|false|Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)|
-|» reason|body|string|false|Reason for the refund. First 9 characters are visible to both parties.|
+|» reason|body|string|false|The first 8 characters are visible if funds are sent via direct credit / BECS, and up to 270 characters if sent via NPP|
 |» your_bank_account_id|body|string(uuid)|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Zepto customisations.|
 
@@ -9953,7 +9953,7 @@ null
 |---|---|---|---|
 |amount|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|
 |channels|array|false|Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)|
-|reason|string|false|Reason for the refund. First 9 characters are visible to both parties.|
+|reason|string|false|The first 8 characters are visible if funds are sent via direct credit / BECS, and up to 270 characters if sent via NPP|
 |your_bank_account_id|string(uuid)|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |metadata|[Metadata](#schemametadata)|false|No description|
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4946,7 +4946,7 @@ components:
           type: array
         reason:
           type: string
-          description: Reason for the refund. First 9 characters are visible to both parties.
+          description: The first 8 characters are visible if funds are sent via direct credit / BECS, and up to 270 characters if sent via NPP
           example: Because reason
         your_bank_account_id:
           type: string


### PR DESCRIPTION
Ticket: [CENT-1214](https://zeptoau.atlassian.net/browse/CENT-1214)

Updates our API docs for our description for the `reason` field in the IssueARefund endpoint.

[CENT-1214]: https://zeptoau.atlassian.net/browse/CENT-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![Screenshot 2025-02-19 at 11 33 17 am](https://github.com/user-attachments/assets/1d5f3402-d8a0-474f-8aa8-6432b510202a)
