### PR TITLE
TRM 1563 - Update api guide with channel switching fail amounts (sandbox)

### DIFF
--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -567,19 +567,19 @@ For example:
 
 You will receive all the same notifications as if this happened in our live environment. We recommend you check out our article on [what happens when an NPP Payment fails](https://help.zepto.money/en/articles/4405560-what-happens-when-an-npp-payment-fails) to learn more about what happens when an NPP Payment is unable to process.
 
-## NPP & DE Payment failures (channel switching)
+## NPP Payment channel-switching failures
 
 ### Using failure codes
 
-> - [NPP and DE failure codes](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745)
+To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired [DE credit failure code](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745). The NPP leg of the payment will fail with error code E303 (this is to facilitate channel-switching where the transaction is set up to do so). If the transaction switches channels the DE leg of the payment will fail with the [DE credit failure code](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745) that corresponds to the amount.
 
-To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired failure code.
+For example: the transaction :
 
-For example, the transaction amount `$4.02` will:
+- payment amount `$1.02` will fail with code `E303` (Account Not NPP Enabled). If the payment channel-switches it will also fail DE processing with code `E102` (Payment Stopped).
 
-- fail NPP processing, triggering credit failure code `E303` (Account Not NPP Enabled)
+- payment amount `$1.05` will fail with code `E303` (Account Not NPP Enabled). If the payment channel-switches it will also fail DE processing with code `E105` (Account Not Found).
 
-- fail DE processing (if the transaction switches channels), triggering the credit failure code that corresponds to the amount, in this case `E102` (Payment Stopped).
+- payment amount `$1.10` will succeed NPP processing, as there is no corresponding DE credit failure code for that amount.
 
 ## Instant account verification accounts
 

--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -525,7 +525,7 @@ Failed transactions will contain the following information inside the event:
 > - [DE credit failure codes](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745)
 > - [DE debit failure codes](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b15d7bd439)
 
-To simulate a transaction failure, create a Payment or Payment Request with an amount corresponding to the desired [failure code](#failure-codes).
+To simulate a transaction failure, create a Payment or Payment Request with an amount corresponding to the desired failure code.
 
 For example:
 
@@ -557,7 +557,7 @@ For example:
 
 > - [NPP credit failure codes](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_81961f33a0)
 
-To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures)
+To simulate a transaction failure, create a Payment with an amount corresponding to the desired failure code.
 
 For example:
 
@@ -566,6 +566,20 @@ For example:
 - NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
 
 You will receive all the same notifications as if this happened in our live environment. We recommend you check out our article on [what happens when an NPP Payment fails](https://help.zepto.money/en/articles/4405560-what-happens-when-an-npp-payment-fails) to learn more about what happens when an NPP Payment is unable to process.
+
+## NPP & DE Payment failures (channel switching)
+
+### Using failure codes
+
+> - [NPP and DE failure codes](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745)
+
+To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired failure code.
+
+For example, the transaction amount `$4.02` will:
+
+- fail NPP processing, triggering credit failure code `E303` (Account Not NPP Enabled)
+
+- fail DE processing (if the transaction switches channels), triggering the credit failure code that corresponds to the amount, in this case `E102` (Payment Stopped).
 
 ## Instant account verification accounts
 

--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -573,7 +573,7 @@ You will receive all the same notifications as if this happened in our live envi
 
 To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired [DE credit failure code](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745). The NPP leg of the payment will fail with error code E303 (this is to facilitate channel-switching where the transaction is set up to do so). If the transaction switches channels the DE leg of the payment will fail with the [DE credit failure code](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745) that corresponds to the amount.
 
-For example: the transaction :
+For example:
 
 - payment amount `$1.02` will fail with code `E303` (Account Not NPP Enabled). If the payment channel-switches it will also fail DE processing with code `E102` (Payment Stopped).
 

--- a/source/guides/zepto-api.md
+++ b/source/guides/zepto-api.md
@@ -522,8 +522,8 @@ Failed transactions will contain the following information inside the event:
 
 ### Using failure codes
 
-> - [DE credit failure codes]("#de-credit-failures")
-> - [DE debit failure codes]("#de-debit-failures)
+> - [DE credit failure codes](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745)
+> - [DE debit failure codes](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b15d7bd439)
 
 To simulate a transaction failure, create a Payment or Payment Request with an amount corresponding to the desired [failure code](#failure-codes).
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -537,13 +537,14 @@ For example:
 * NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
 
 You will receive all the same notifications as if this happened in our live environment. We recommend you check out our article on [what happens when an NPP Payment fails](https://help.zepto.money/en/articles/4405560-what-happens-when-an-npp-payment-fails) to learn more about what happens when an NPP Payment is unable to process.
-## NPP & DE Payment failures (channel switching)
+## NPP Payment channel-switching failures
 ### Using failure codes
-To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired failure code.
-For example, the transaction amount `$4.02` will:
+To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired [DE credit failure code](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745). The NPP leg of the payment will fail with error code E303 (this is to facilitate channel-switching where the transaction is set up to do so). If the transaction switches channels the DE leg of the payment will fail with the [DE credit failure code](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745) that corresponds to the amount.
+For example:
 
-* fail NPP processing, triggering credit failure code `E303` (Account Not NPP Enabled).
-* fail DE processing (if the transaction switches channels), triggering the credit failure code that corresponds to the amount, in this case `E102` (Payment Stopped).
+* payment amount `$1.02` will fail with code `E303` (Account Not NPP Enabled). If the payment channel-switches it will also fail DE processing with code `E102` (Payment Stopped).
+* payment amount `$1.05` will fail with code `E303` (Account Not NPP Enabled). If the payment channel-switches it will also fail DE processing with code `E105` (Account Not Found).
+* payment amount `$1.10` will succeed NPP processing, as there is no corresponding DE credit failure code for that amount.
 
 # Configuration
 ## Scopes

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -537,6 +537,14 @@ For example:
 * NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
 
 You will receive all the same notifications as if this happened in our live environment. We recommend you check out our article on [what happens when an NPP Payment fails](https://help.zepto.money/en/articles/4405560-what-happens-when-an-npp-payment-fails) to learn more about what happens when an NPP Payment is unable to process.
+## NPP & DE Payment failures (channel switching)
+### Using failure codes
+To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired failure code.
+For example, the transaction amount `$4.02` will:
+
+* fail NPP processing, triggering credit failure code `E303` (Account Not NPP Enabled).
+* fail DE processing (if the transaction switches channels), triggering the credit failure code that corresponds to the amount, in this case `E102` (Payment Stopped).
+
 # Configuration
 ## Scopes
 Scopes define the level of access granted via the OAuth2 authorisation process. As a best practice, only use the scopes your application will require.

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -815,18 +815,20 @@ info:
     check out our article on [what happens when an NPP Payment fails](https://help.zepto.money/en/articles/4405560-what-happens-when-an-npp-payment-fails)
     to learn more about what happens when an NPP Payment is unable to process.
 
-    ## NPP & DE Payment failures (channel switching)
+    ## NPP Payment channel-switching failures
 
     ### Using failure codes
-
-    To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired failure code.
-
-    For example, the transaction amount `$4.02` will:
     
+    To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired [DE credit failure code](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745). The NPP leg of the payment will fail with error code E303 (this is to facilitate channel-switching where the transaction is set up to do so). If the transaction switches channels the DE leg of the payment will fail with the [DE credit failure code](https://help.zepto.money/en/articles/5633407-au-transaction-failure-responses#h_b2229b3745) that corresponds to the amount.
+  
+    For example:
 
-    * fail NPP processing, triggering credit failure code `E303` (Account Not NPP Enabled).
 
-    * fail DE processing (if the transaction switches channels), triggering the credit failure code that corresponds to the amount, in this case `E102` (Payment Stopped).
+    * payment amount `$1.02` will fail with code `E303` (Account Not NPP Enabled). If the payment channel-switches it will also fail DE processing with code `E102` (Payment Stopped).
+
+    * payment amount `$1.05` will fail with code `E303` (Account Not NPP Enabled). If the payment channel-switches it will also fail DE processing with code `E105` (Account Not Found).
+
+    * payment amount `$1.10` will succeed NPP processing, as there is no corresponding DE credit failure code for that amount.
 
     
     # Configuration

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -815,6 +815,20 @@ info:
     check out our article on [what happens when an NPP Payment fails](https://help.zepto.money/en/articles/4405560-what-happens-when-an-npp-payment-fails)
     to learn more about what happens when an NPP Payment is unable to process.
 
+    ## NPP & DE Payment failures (channel switching)
+
+    ### Using failure codes
+
+    To simulate a transaction failure across both NPP and DE channels, create a Payment with an amount corresponding to the desired failure code.
+
+    For example, the transaction amount `$4.02` will:
+    
+
+    * fail NPP processing, triggering credit failure code `E303` (Account Not NPP Enabled).
+
+    * fail DE processing (if the transaction switches channels), triggering the credit failure code that corresponds to the amount, in this case `E102` (Payment Stopped).
+
+    
     # Configuration
 
     ## Scopes


### PR DESCRIPTION
This PR updates the "Zepto API" guide with info about new transaction amounts to simulate NPP and DE failures in Sandbox ([TRM-1563](https://zeptoau.atlassian.net/browse/TRM-1563)), introduced in https://github.com/zeptofs/split/pull/13145.

<img width="657" alt="Screenshot 2025-02-27 at 4 48 13 pm" src="https://github.com/user-attachments/assets/21ac64d5-aaac-42aa-86e1-9d730b01c18f" />



[TRM-1563]: https://zeptoau.atlassian.net/browse/TRM-1563