### PR TITLE
TRM-2269 Add description pattern to /payments endpoint 

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3907,14 +3907,14 @@ To enable custom payment flows, the required payment channel can be selected by 
 |---|---|---|---|---|
 |Idempotency-Key|header|string|true|Idempotency key to support safe retries for 24h|
 |body|body|[MakeAPaymentRequest](#schemamakeapaymentrequest)|true|No description|
-|» description|body|string|true|User description. Only visible to the payer|
+|» description|body|string|true|User description. Only visible to the payer. ASCII-printable characters and unicode emojis are accepted.|
 |» matures_at|body|string(date-time)|true|Date & time in UTC ISO8601 the Payment should be processed. (Can not be earlier than the start of current day in Sydney AEST/AEDT)|
 |» your_bank_account_id|body|string|true|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |» channels|body|array|true|Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)|
 |» payouts|body|[[Payout](#schemapayout)]|true|One Payout object only|
 |»» Payout|body|[Payout](#schemapayout)|false|The actual Payout|
 |»»» amount|body|integer|true|Amount in cents to pay the recipient|
-|»»» description|body|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
+|»»» description|body|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description. ASCII-printable characters and unicode emojis are accepted.|
 |»»» recipient_contact_id|body|string|true|Contact to pay (`Contact.data.id`)|
 |»»» category_purpose_code|body|string|false|ISO 20022 code for payment category purpose (see supported values below).|
 |»»» end_to_end_id|body|string|false|End-To-End ID (35 max. characters). Required when a category purpose code is present. For superannuation or tax payments, set this to the Payment Reference Number (PRN). For salary payments, set this to the Employee Reference.|
@@ -8406,7 +8406,7 @@ Use this endpoint to resend a failed webhook delivery.
 
 |Name|Type|Required|Description|
 |---|---|---|---|
-|description|string|true|User description. Only visible to the payer|
+|description|string|true|User description. Only visible to the payer. ASCII-printable characters and unicode emojis are accepted.|
 |matures_at|string(date-time)|true|Date & time in UTC ISO8601 the Payment should be processed. (Can not be earlier than the start of current day in Sydney AEST/AEDT)|
 |your_bank_account_id|string|true|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |channels|array|true|Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)|
@@ -8435,7 +8435,7 @@ Use this endpoint to resend a failed webhook delivery.
 |Name|Type|Required|Description|
 |---|---|---|---|
 |amount|integer|true|Amount in cents to pay the recipient|
-|description|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
+|description|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description. ASCII-printable characters and unicode emojis are accepted.|
 |recipient_contact_id|string|true|Contact to pay (`Contact.data.id`)|
 |category_purpose_code|string|false|ISO 20022 code for payment category purpose (see supported values below).|
 |end_to_end_id|string|false|End-To-End ID (35 max. characters). Required when a category purpose code is present. For superannuation or tax payments, set this to the Payment Reference Number (PRN). For salary payments, set this to the Employee Reference.|

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -2662,8 +2662,8 @@ components:
       properties:
         description:
           type: string
-          description: User description. Only visible to the payer
-           pattern: '^[ -~p{Emoji}]+$'
+          description: User description. Only visible to the payer. ASCII-printable characters and unicode emojis are accepted.
+          pattern: "^[ -~\\p{Emoji}]+$"
           example: The SuperPackage
         matures_at:
           type: string
@@ -2721,8 +2721,8 @@ components:
           example: 30000
         description:
           type: string
-          description: Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.
-          pattern: '^[ -~p{Emoji}]+$'
+          description: Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description. ASCII-printable characters and unicode emojis are accepted.
+          pattern: "^[ -~\\p{Emoji}]+$"
           example: A tandem skydive jump SB23094
         recipient_contact_id:
           type: string

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -2663,6 +2663,7 @@ components:
         description:
           type: string
           description: User description. Only visible to the payer
+           pattern: '^[ -~p{Emoji}]+$'
           example: The SuperPackage
         matures_at:
           type: string
@@ -2721,6 +2722,7 @@ components:
         description:
           type: string
           description: Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.
+          pattern: '^[ -~p{Emoji}]+$'
           example: A tandem skydive jump SB23094
         recipient_contact_id:
           type: string


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

We are updating the POST /payments endpoints description regex pattern from a normal string (that accepts any ascii or control char) to a stricter string regex (accepts ASCII printable and unicode emojis). 

Parent PR from Split repo - https://github.com/zeptofs/split/pull/13254. Will be merging this after confirming with Product for merchant comms.

We do not have any `pattern` defined before in `split.yaml`. Moreover, when I run locally, the older version of API doc doesn't show any patterns. And that is why I think, it didn't update `source/index.html.md`. Testing seems harder here. Please let me know if anyone has got any ideas how I can test this somehow.

Output:

![image](https://github.com/user-attachments/assets/7f337987-a1db-404c-92b2-7981983fccbf)
