### PR TITLE
Add ASCII pattern validation to Contacts endpoint

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -988,7 +988,7 @@ Use this endpoint when you want to pay somebody.
 |Parameter|In|Type|Required|Description|
 |---|---|---|---|---|
 |body|body|[AddAnAnyoneContactRequest](#schemaaddananyonecontactrequest)|true|No description|
-|» name|body|string|true|The name of the Contact (140 max. characters)|
+|» name|body|string|true|The name of the Contact (140 max. characters, ASCII characters only)|
 |» email|body|string|true|The email of the Contact (256 max. characters)|
 |» branch_code|body|string|true|The bank account BSB of the Contact|
 |» account_number|body|string|true|The bank account number of the Contact|
@@ -8084,7 +8084,7 @@ Use this endpoint to resend a failed webhook delivery.
 
 |Name|Type|Required|Description|
 |---|---|---|---|
-|name|string|true|The name of the Contact (140 max. characters)|
+|name|string|true|The name of the Contact (140 max. characters, ASCII characters only)|
 |email|string|true|The email of the Contact (256 max. characters)|
 |branch_code|string|true|The bank account BSB of the Contact|
 |account_number|string|true|The bank account number of the Contact|

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -2080,6 +2080,7 @@ components:
           type: string
           minLength: 3
           maxLength: 140
+          pattern: "^[ -~]+$"
           description: 'Contact name (Min: 3 - Max: 140)'
         email:
           type: string
@@ -2326,9 +2327,12 @@ components:
       properties:
         name:
           type: string
-          description: The name of the Contact (140 max. characters)
+          pattern: "^[ -~]+$"
+          maxLength: 140
+          description: The name of the Contact (140 max. characters, ASCII characters only)
         email:
           type: string
+          maxLength: 256
           description: The email of the Contact (256 max. characters)
         branch_code:
           type: string


### PR DESCRIPTION
This PR updates our API docs to add a REGEX pattern matching to the API documentation for the Contacts endpoint.  The intended pattern matching here is to support these characters: `+@!^$&'()*-:;=?.#_,[]/` and exclude special accents, e.g.:  `à, è, ì, ò, ù`

Also added some length validations to the API docs where they were missing. 