### PR TITLE
TRM-2541 Transfers Description validation pattern

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -6288,7 +6288,7 @@ Use this endpoint when you want to create a Transfer between any 2 of your float
 |» from_bank_account_id|body|string|true|The source float/bank account (UUID)|
 |» to_bank_account_id|body|string|true|The destination float/bank account (UUID)|
 |» amount|body|integer|true|Amount in cents (Min: 1 - Max: 99999999999)|
-|» description|body|string|true|Description for the Transfer|
+|» description|body|string|true|Description for the Transfer. ASCII-printable characters and unicode emojis are accepted.|
 |» matures_at|body|string(date-time)|true|Date & time in UTC ISO8601 the Transfer should be processed. (Can not be earlier than the start of current day in Sydney AEST/AEDT)|
 
 > Example responses
@@ -9522,7 +9522,7 @@ null
 |from_bank_account_id|string|true|The source float/bank account (UUID)|
 |to_bank_account_id|string|true|The destination float/bank account (UUID)|
 |amount|integer|true|Amount in cents (Min: 1 - Max: 99999999999)|
-|description|string|true|Description for the Transfer|
+|description|string|true|Description for the Transfer. ASCII-printable characters and unicode emojis are accepted.|
 |matures_at|string(date-time)|true|Date & time in UTC ISO8601 the Transfer should be processed. (Can not be earlier than the start of current day in Sydney AEST/AEDT)|
 
 ## AddATransferResponse

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -4084,8 +4084,8 @@ components:
           description: 'Amount in cents (Min: 1 - Max: 99999999999)'
         description:
           type: string
-          pattern: "^[ -~]+$"
-          description: Description for the Transfer
+          pattern: "^[ -~\\p{Emoji}]+$"
+          description: Description for the Transfer. ASCII-printable characters and unicode emojis are accepted.
         matures_at:
           type: string
           format: date-time


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
Parent PR from Split Repo:
1) Non prod rollout - https://github.com/zeptofs/split/pull/13675
2) prod rollout - https://github.com/zeptofs/split/pull/13676

We are updating the Transfer's description pattern to accept ascii printable and unicode emojis.

Output:

<img width="945" height="721" alt="image" src="https://github.com/user-attachments/assets/aa405961-d53f-4590-bf0b-a263d9282553" />
