### PR TITLE
Document errors in `receivable/activate` endpoint

### DIFF
--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -718,6 +718,10 @@ paths:
                   summary: Bank account not blocked
                   value:
                     errors: Bank account must be blocked.
+                Bank account already unblocked:
+                  summary: Bank account already unblocked
+                  value:
+                    errors: Bank account is already unblocked
         '404':
           description: Not Found
   '/contacts/{contact_id}/receivable':

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -710,6 +710,10 @@ paths:
                   summary: PayID is not disabled
                   value:
                     errors: Contact must be 'disabled' but is '{status}'.
+                Contact blocked by a Split admin:
+                  summary: Contact blocked by a Split admin
+                  value:
+                    errors: This receivable contact can only be enabled by a Split administrator. Please contact Split for further information
         '404':
           description: Not Found
   '/contacts/{contact_id}/receivable':

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -703,14 +703,6 @@ paths:
                     type: string
         '404':
           description: Not Found
-        '422':
-          description: Unprocessable Entity
-          content:
-            application/json:
-              schema:
-                properties:
-                  errors:
-                    type: string
   '/contacts/{contact_id}/receivable':
     patch:
       tags:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -703,6 +703,14 @@ paths:
                     type: string
         '404':
           description: Not Found
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                properties:
+                  errors:
+                    type: string
   '/contacts/{contact_id}/receivable':
     patch:
       tags:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -706,6 +706,10 @@ paths:
                   summary: Contact is not receivable
                   value:
                     errors: Contact is not receivable
+                PayID is not disabled:
+                  summary: PayID is not disabled
+                  value:
+                    errors: Contact must be 'disabled' but is '{status}'.
         '404':
           description: Not Found
   '/contacts/{contact_id}/receivable':

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -722,6 +722,10 @@ paths:
                   summary: Bank account already unblocked
                   value:
                     errors: Bank account is already unblocked
+                Bank account already unblocked for credits:
+                  summary: Bank account already unblocked for credits
+                  value:
+                    errors: Bank account is already unblocked for credits
         '404':
           description: Not Found
   '/contacts/{contact_id}/receivable':

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -701,6 +701,11 @@ paths:
                 properties:
                   errors:
                     type: string
+              examples:
+                Contact is not receivable:
+                  summary: Contact is not receivable
+                  value:
+                    errors: Contact is not receivable
         '404':
           description: Not Found
   '/contacts/{contact_id}/receivable':

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -710,10 +710,10 @@ paths:
                   summary: PayID is not disabled
                   value:
                     errors: Contact must be 'disabled' but is '{status}'.
-                Contact blocked by a Split admin:
-                  summary: Contact blocked by a Split admin
+                Contact blocked by a Zepto admin:
+                  summary: Contact blocked by a Zepto admin
                   value:
-                    errors: This receivable contact can only be enabled by a Split administrator. Please contact Split for further information
+                    errors: This receivable contact can only be enabled by Zepto support. Please contact Zepto for further information
                 Bank account not blocked:
                   summary: Bank account not blocked
                   value:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -695,6 +695,12 @@ paths:
           description: No Content (success)
         '400':
           description: Bad Request (errors)
+          content:
+            application/json:
+              schema:
+                properties:
+                  errors:
+                    type: string
         '404':
           description: Not Found
   '/contacts/{contact_id}/receivable':

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -714,6 +714,10 @@ paths:
                   summary: Contact blocked by a Split admin
                   value:
                     errors: This receivable contact can only be enabled by a Split administrator. Please contact Split for further information
+                Bank account not blocked:
+                  summary: Bank account not blocked
+                  value:
+                    errors: Bank account must be blocked.
         '404':
           description: Not Found
   '/contacts/{contact_id}/receivable':

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -726,6 +726,10 @@ paths:
                   summary: Bank account already unblocked for credits
                   value:
                     errors: Bank account is already unblocked for credits
+                Bank account already unblocked for debits:
+                  summary: Bank account already unblocked for debits
+                  value:
+                    errors: Bank account is already unblocked for debits
         '404':
           description: Not Found
   '/contacts/{contact_id}/receivable':


### PR DESCRIPTION
This should close this [card](https://zeptoau.atlassian.net/jira/software/projects/TRM/boards/38?selectedIssue=TRM-2698).

Different from `Zepto PayTo API`, we don't have error codes in `Zepto API`, so this PR's approach is to add an example of every possible error in the `receivables/activate` endpoint (besides the error codes, we also do that in `Zepto PayTo API`).