### PR TITLE
Upgrade README docs sync

### DIFF
--- a/.github/workflows/readme-docs.yml
+++ b/.github/workflows/readme-docs.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run `docs` command 🚀
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v10
         with:
-          rdme: docs source/guides/ --key=${{ secrets.README_API_KEY }} --version=1.0
+          rdme: docs upload source/guides/ --key=${{ secrets.README_API_KEY }} --branch=1.0


### PR DESCRIPTION
`main` is [no longer working](https://github.com/zeptofs/api-documentation/actions/runs/18669387095).

## Migration guide

- [`docs` has been renamed to `docs upload`](https://github.com/readmeio/rdme/blob/v10/documentation/migration-guide.md#:~:text=rdme%20docs%20upload%20(or%20rdme%20reference%20upload%20if%20you're%20uploading%20Markdown%20to%20your%20API%20Reference%20section)).
- [`--version` is now `--branch`](https://github.com/readmeio/rdme/blob/v10/documentation/migration-guide.md#:~:text=This%20flag%20has%20also%20been%20renamed%20to%20%2D%2Dbranch).

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->